### PR TITLE
Fix double modal around new task popup

### DIFF
--- a/src/tui/picker.rs
+++ b/src/tui/picker.rs
@@ -7,7 +7,7 @@ use crossterm::{
     ExecutableCommand,
 };
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Paragraph};
 use std::io::stdout;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -224,18 +224,18 @@ fn draw_picker(frame: &mut Frame, picker: &Picker) {
 }
 
 fn draw_repo_phase(frame: &mut Frame, area: Rect, picker: &Picker) {
-    let block = Block::default()
-        .title(Span::styled(" select repo ", theme::title()))
-        .borders(Borders::ALL)
-        .border_style(theme::border_active())
-        .style(Style::default().bg(theme::COMB));
+    let inner = area;
 
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    // Title
+    let title = Line::from(Span::styled(" select repo", theme::title()));
+    frame.render_widget(
+        Paragraph::new(title),
+        Rect::new(inner.x, inner.y, inner.width, 1),
+    );
 
     for (i, repo) in picker.repos.iter().enumerate() {
         let is_selected = i == picker.repo_index;
-        let y = inner.y + 1 + i as u16;
+        let y = inner.y + 2 + i as u16;
         if y >= inner.y + inner.height.saturating_sub(1) {
             break;
         }
@@ -272,14 +272,7 @@ fn draw_repo_phase(frame: &mut Frame, area: Rect, picker: &Picker) {
 }
 
 fn draw_input_phase(frame: &mut Frame, area: Rect, picker: &Picker) {
-    let block = Block::default()
-        .title(Span::styled(" task ", theme::title()))
-        .borders(Borders::ALL)
-        .border_style(theme::border_active())
-        .style(Style::default().bg(theme::COMB));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = area;
 
     // Show repo context if multi-repo
     if picker.repos.len() > 1 {
@@ -339,19 +332,18 @@ fn draw_input_phase(frame: &mut Frame, area: Rect, picker: &Picker) {
 
 fn draw_agent_phase(frame: &mut Frame, area: Rect, picker: &Picker) {
     let agents = AgentKind::all();
+    let inner = area;
 
-    let block = Block::default()
-        .title(Span::styled(" select agent ", theme::title()))
-        .borders(Borders::ALL)
-        .border_style(theme::border_active())
-        .style(Style::default().bg(theme::COMB));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    // Title
+    let title = Line::from(Span::styled(" select agent", theme::title()));
+    frame.render_widget(
+        Paragraph::new(title),
+        Rect::new(inner.x, inner.y, inner.width, 1),
+    );
 
     for (i, agent) in agents.iter().enumerate() {
         let is_selected = i == picker.agent_index;
-        let y = inner.y + 1 + i as u16;
+        let y = inner.y + 2 + i as u16;
         if y >= inner.y + inner.height.saturating_sub(3) {
             break;
         }


### PR DESCRIPTION
## Summary
- Removed inner ratatui `Block` borders from all three picker phases (`draw_repo_phase`, `draw_input_phase`, `draw_agent_phase`)
- The tmux popup already provides a bordered container with the "new task" title, so the picker's own borders created a nested double-modal effect
- Phases now render content directly into the popup area with inline title labels where needed

## Test plan
- [ ] Press `n` on the welcome screen — should see a single bordered popup, not nested borders
- [ ] Verify repo select, task input, and agent select phases all render cleanly inside the popup
- [ ] Multi-repo: verify repo picker phase shows title and list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)