### PR TITLE
Fix sidebar navigation inadvertently selecting tmux panes

### DIFF
--- a/src/core/tmux.rs
+++ b/src/core/tmux.rs
@@ -449,9 +449,10 @@ pub fn apply_session_style(session: &str) -> Result<()> {
 }
 
 /// Set a pane's individual style (background/foreground).
+/// Uses set-option instead of select-pane to avoid focusing the pane as a side effect.
 pub fn set_pane_style(pane_id: &str, style: &str) -> Result<()> {
     Command::new("tmux")
-        .args(["select-pane", "-t", pane_id, "-P", style])
+        .args(["set-option", "-p", "-t", pane_id, "style", style])
         .output()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- `set_pane_style()` was using `tmux select-pane -t <pane> -P <style>` to apply dimming styles to non-selected panes
- `select-pane` has the side effect of actually focusing the target pane, so navigating up/down in the sidebar was switching tmux focus
- Switched to `tmux set-option -p -t <pane> style <style>` which applies the style without changing pane focus

## Test plan
- [ ] Navigate up/down in the sidebar — only the sidebar highlight should move, tmux pane focus should stay on the sidebar
- [ ] Verify dimmed/bright styling still applies correctly to non-selected vs selected worktree panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)