### PR TITLE
Add `p` keybinding to show PR URL in status bar

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -536,6 +536,19 @@ impl App {
         }
     }
 
+    pub fn show_pr_url(&mut self) {
+        if self.worktrees.is_empty() {
+            self.flash("no worktree selected".to_string());
+            return;
+        }
+        let wt = &self.worktrees[self.selected];
+        if let Some(ref pr) = wt.pr {
+            self.flash(pr.url.clone());
+        } else {
+            self.flash("no PR found for this worktree".to_string());
+        }
+    }
+
     pub fn add_terminal_to_selected(&mut self) {
         if self.worktrees.is_empty() {
             self.flash("no worktree selected".to_string());
@@ -1007,7 +1020,13 @@ impl App {
 
     pub fn current_status(&self) -> Option<&str> {
         self.status_message.as_ref().and_then(|(msg, when)| {
-            let duration = if msg.starts_with("error") { 10 } else { 4 };
+            let duration = if msg.starts_with("error") {
+                10
+            } else if msg.starts_with("http") {
+                30
+            } else {
+                4
+            };
             if when.elapsed().as_secs() < duration {
                 Some(msg.as_str())
             } else {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -58,6 +58,7 @@ async fn event_loop(
                         }
                         KeyCode::Char('n') => app.start_new_worktree(),
                         KeyCode::Char('t') => app.add_terminal_to_selected(),
+                        KeyCode::Char('p') => app.show_pr_url(),
                         KeyCode::Char('j') | KeyCode::Down => app.select_next(),
                         KeyCode::Char('k') | KeyCode::Up => app.select_prev(),
                         KeyCode::Enter => app.jump_to_selected(),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -680,6 +680,7 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
     let keys = vec![
         ("n", "new worktree + agent"),
         ("t", "add terminal pane"),
+        ("p", "show PR url"),
         ("j/k", "navigate worktrees"),
         ("\u{21b5}", "jump to agent pane"),
         ("m", "merge worktree to base"),


### PR DESCRIPTION
## Summary
- Adds `p` keybinding in Normal mode that flashes the selected worktree's PR URL in the status bar
- URL stays visible for 30 seconds (vs 4s default) so it can be cmd+clicked over SSH
- Shows "no PR found for this worktree" if no PR exists yet
- Help overlay updated with the new keybinding

## Test plan
- [ ] Select a worktree with a PR and press `p` — URL should appear in status bar
- [ ] Verify the URL is cmd+clickable in terminal
- [ ] Select a worktree without a PR and press `p` — should show "no PR found" message
- [ ] Press `?` and verify `p  show PR url` appears in help

🤖 Generated with [Claude Code](https://claude.com/claude-code)