### PR TITLE
Auto-close worktrees when their PR is merged

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1078,6 +1078,8 @@ impl App {
     // ── PR Status ──────────────────────────────────────────
 
     fn refresh_pr_statuses(&mut self) {
+        let mut merged_ids = Vec::new();
+
         for wt in &mut self.worktrees {
             if wt.branch.is_empty() {
                 continue;
@@ -1104,10 +1106,14 @@ impl App {
                     let text = String::from_utf8_lossy(&output.stdout);
                     if let Ok(prs) = serde_json::from_str::<Vec<serde_json::Value>>(text.trim()) {
                         if let Some(pr) = prs.first() {
+                            let state = pr["state"].as_str().unwrap_or("").to_string();
+                            if state == "MERGED" && wt.pr.as_ref().map_or(true, |p| p.state != "MERGED") {
+                                merged_ids.push(wt.id.clone());
+                            }
                             wt.pr = Some(PrInfo {
                                 number: pr["number"].as_u64().unwrap_or(0),
                                 title: pr["title"].as_str().unwrap_or("").to_string(),
-                                state: pr["state"].as_str().unwrap_or("").to_string(),
+                                state,
                                 url: pr["url"].as_str().unwrap_or("").to_string(),
                             });
                         } else {
@@ -1115,6 +1121,15 @@ impl App {
                         }
                     }
                 }
+            }
+        }
+
+        // Auto-close worktrees whose PRs were just merged
+        for id in merged_ids {
+            if let Some(idx) = self.worktrees.iter().position(|w| w.id == id) {
+                let prompt = self.worktrees[idx].prompt.clone();
+                let _ = self.close_worktree(idx);
+                self.flash(format!("auto-closed \"{}\" (PR merged)", prompt));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Worktrees now automatically close when their associated PR is detected as merged during the 30s poll cycle
- Shows a flash message like `auto-closed "task prompt" (PR merged)` so the user knows what happened
- Only triggers on the transition to merged state, not on every subsequent poll

## Test plan
- [ ] Create a worktree, push a PR from it, merge the PR on GitHub, and verify the worktree auto-closes within ~30s
- [ ] Verify the flash message appears in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)