### PR TITLE
Improve selected pane visibility

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,8 +9,9 @@ use std::time::Instant;
 
 /// Pane foreground colors for selected/dimmed states.
 const PANE_FG_SELECTED: &str = "#dcdce1"; // full FROST brightness
-const PANE_FG_DIMMED: &str = "#6e6b65"; // ~40% dimmed
-const PANE_BG: &str = "#282520"; // COMB (unchanged for both)
+const PANE_FG_DIMMED: &str = "#504d48"; // heavily dimmed
+const PANE_BG_SELECTED: &str = "#282520"; // COMB — normal brightness
+const PANE_BG_DIMMED: &str = "#1a1816"; // darkened, receded
 
 /// Hex colors for worktree pane border titles.
 const WORKTREE_BORDER_COLORS: &[&str] = &[
@@ -1296,7 +1297,8 @@ impl App {
         for idx in indices_to_update {
             let is_selected = idx == selected;
             let fg = if is_selected { PANE_FG_SELECTED } else { PANE_FG_DIMMED };
-            let style = format!("bg={},fg={}", PANE_BG, fg);
+            let bg = if is_selected { PANE_BG_SELECTED } else { PANE_BG_DIMMED };
+            let style = format!("bg={},fg={}", bg, fg);
 
             if let Some(wt) = self.worktrees.get(idx) {
                 if let Some(ref agent) = wt.agent {


### PR DESCRIPTION
## Summary
- Darken non-selected pane backgrounds (`#282520` → `#1a1816`) so they visually recede
- Dim non-selected pane text more aggressively (`#6e6b65` → `#504d48`)
- Selected pane stays at full brightness, making it much easier to spot at a glance

## Test plan
- [ ] Launch swarm with 2+ worktrees and verify the selected pane clearly stands out
- [ ] Navigate between worktrees with j/k and confirm the brightness shift is immediate and obvious

🤖 Generated with [Claude Code](https://claude.com/claude-code)