### PR TITLE
Fix tiled layout by rebalancing after pane registration

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -485,18 +485,18 @@ impl App {
         let cmd = agent.launch_cmd_with_prompt(&prompt, true);
         tmux::send_keys_to_pane(&pane_id, &cmd)?;
 
-        // Rebalance, re-apply styling, re-select sidebar
-        self.rebalance_layout();
-        let _ = tmux::apply_session_style(&self.session_name);
-        if let Some(ref sidebar) = self.sidebar_pane_id {
-            let _ = tmux::select_pane(sidebar);
-        }
-
         self.worktrees[idx].agent = Some(TrackedPane {
             pane_id: pane_id.clone(),
             status: PaneStatus::Running,
         });
         self.worktrees[idx].pending_prompt = None;
+
+        // Rebalance, re-apply styling, re-select sidebar (after setting agent so pane is included)
+        self.rebalance_layout();
+        let _ = tmux::apply_session_style(&self.session_name);
+        if let Some(ref sidebar) = self.sidebar_pane_id {
+            let _ = tmux::select_pane(sidebar);
+        }
         self.apply_worktree_color(idx);
         self.update_pane_selection();
         self.save_state();
@@ -833,15 +833,6 @@ impl App {
         let cmd = agent.launch_cmd_with_prompt(prompt, true);
         tmux::send_keys_to_pane(&pane_id, &cmd)?;
 
-        // Rebalance layout and re-apply styling
-        self.rebalance_layout();
-        let _ = tmux::apply_session_style(&self.session_name);
-
-        // Re-select sidebar pane so TUI keeps focus
-        if let Some(ref sidebar) = self.sidebar_pane_id {
-            let _ = tmux::select_pane(sidebar);
-        }
-
         self.worktrees.push(Worktree {
             id: window_name.clone(),
             branch: branch_name.clone(),
@@ -863,6 +854,15 @@ impl App {
         self.apply_worktree_color(self.selected);
         self.prev_selected = None;
         self.update_pane_selection();
+
+        // Rebalance layout and re-apply styling (after push so the new pane is included)
+        self.rebalance_layout();
+        let _ = tmux::apply_session_style(&self.session_name);
+
+        // Re-select sidebar pane so TUI keeps focus
+        if let Some(ref sidebar) = self.sidebar_pane_id {
+            let _ = tmux::select_pane(sidebar);
+        }
         self.save_state();
 
         // Emit event


### PR DESCRIPTION
## Summary
- `rebalance_layout()` was called **before** the new worktree/agent pane was registered in `self.worktrees`, so the tiled layout calculation always missed the newest pane
- With 2 tasks it only saw 1 group (single column → vertical stack), with 3 it only saw 2, etc.
- Moved the rebalance call to after the push/registration in both the create-worktree and restore-agent paths

## Test plan
- [ ] Create 2 worktrees — agent panes should appear side-by-side (2 columns)
- [ ] Create 3-4 worktrees — should tile into a grid layout
- [ ] Restore agents (kill and relaunch) — layout should still rebalance correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)