### PR TITLE
Fix non-active pane dimming

### DIFF
--- a/src/core/tmux.rs
+++ b/src/core/tmux.rs
@@ -379,17 +379,19 @@ pub fn pane_exists(pane_id: &str) -> bool {
 
 /// Apply session styling: pane borders, colors, background, disable status bar.
 pub fn apply_session_style(session: &str) -> Result<()> {
-    // Dark background + light text for ALL panes (COMB bg, FROST fg)
+    // Default pane style: dimmed (non-selected panes recede visually).
+    // Per-pane overrides brighten the selected worktree's panes.
     let _ = Command::new("tmux")
         .args([
             "set-option", "-t", session,
-            "window-style", "bg=#282520,fg=#dcdce1",
+            "window-style", "bg=#1a1816,fg=#504d48,dim",
         ])
         .output();
+    // Active pane (sidebar, or whichever has tmux focus) stays bright
     let _ = Command::new("tmux")
         .args([
             "set-option", "-t", session,
-            "window-active-style", "bg=#282520,fg=#dcdce1",
+            "window-active-style", "bg=#282520,fg=#dcdce1,nodim",
         ])
         .output();
     // Padded borders for visible gaps between panes

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,8 @@ async fn run_sidebar(work_dir: std::path::PathBuf, agent: String) -> Result<()> 
             app.sidebar_pane_id = get_current_pane_id();
             if let Some(ref pane_id) = app.sidebar_pane_id {
                 let _ = core::tmux::set_pane_title(pane_id, "swarm");
+                // Keep sidebar bright even when window-style defaults to dimmed
+                let _ = core::tmux::set_pane_style(pane_id, "bg=#282520,fg=#dcdce1,nodim");
             }
             app.save_state();
             tui::run(&mut app).await?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -852,9 +852,6 @@ impl App {
         });
 
         self.selected = self.worktrees.len() - 1;
-        self.apply_worktree_color(self.selected);
-        self.prev_selected = None;
-        self.update_pane_selection();
 
         // Rebalance layout and re-apply styling (after push so the new pane is included)
         self.rebalance_layout();
@@ -864,6 +861,12 @@ impl App {
         if let Some(ref sidebar) = self.sidebar_pane_id {
             let _ = tmux::select_pane(sidebar);
         }
+
+        // Apply per-pane colors/selection AFTER layout + session style
+        // so they aren't overwritten by rebalance or apply_session_style
+        self.apply_worktree_color(self.selected);
+        self.prev_selected = None;
+        self.update_pane_selection();
         self.save_state();
 
         // Emit event
@@ -1271,6 +1274,12 @@ impl App {
     /// Update pane selection styling — dims non-selected worktrees, brightens selected.
     /// Uses delta updates when possible (only touches changed worktrees).
     fn update_pane_selection(&mut self) {
+        // Always keep sidebar pane bright (even when it loses tmux focus)
+        if let Some(ref sidebar) = self.sidebar_pane_id {
+            let bright = format!("bg={},fg={},nodim", PANE_BG_SELECTED, PANE_FG_SELECTED);
+            let _ = tmux::set_pane_style(sidebar, &bright);
+        }
+
         if self.worktrees.is_empty() {
             self.prev_selected = None;
             return;
@@ -1298,7 +1307,12 @@ impl App {
             let is_selected = idx == selected;
             let fg = if is_selected { PANE_FG_SELECTED } else { PANE_FG_DIMMED };
             let bg = if is_selected { PANE_BG_SELECTED } else { PANE_BG_DIMMED };
-            let style = format!("bg={},fg={}", bg, fg);
+            // Use dim/nodim attribute so colorized terminal output is also affected
+            let style = if is_selected {
+                format!("bg={},fg={},nodim", bg, fg)
+            } else {
+                format!("bg={},fg={},dim", bg, fg)
+            };
 
             if let Some(wt) = self.worktrees.get(idx) {
                 if let Some(ref agent) = wt.agent {


### PR DESCRIPTION
## Summary
- **Use tmux `dim` attribute**: Previously only `fg`/`bg` colors were changed, which had no effect on text with explicit SGR colors (like Claude Code's colorized output). The `dim` attribute halves brightness of ALL foreground text, making dimming actually visible.
- **Fix style ordering**: Per-pane color/selection was applied *before* `rebalance_layout()` and `apply_session_style()`, which overwrote the dimming. Now applied after.
- **Default `window-style` to dimmed**: Changed from bright to dimmed so panes without per-pane overrides recede visually by default. Sidebar gets explicit bright per-pane style so it stays readable.

## Test plan
- [ ] Launch swarm, create 2+ worktrees with agents
- [ ] Verify non-selected worktree panes appear visibly dimmed (darker background + reduced text brightness)
- [ ] Navigate between worktrees with j/k and verify dimming updates correctly
- [ ] Verify sidebar TUI remains bright and readable at all times
- [ ] Click on an agent pane to interact, then return to sidebar — verify sidebar stays bright

🤖 Generated with [Claude Code](https://claude.com/claude-code)