### PR TITLE
Add LLM-generated task summaries to sidebar

### DIFF
--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -30,6 +30,8 @@ pub struct WorktreeState {
     pub agent: Option<PaneState>,
     #[serde(default)]
     pub terminals: Vec<PaneState>,
+    #[serde(default)]
+    pub summary: Option<String>,
 }
 
 /// All swarm state for a workspace.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,6 +6,7 @@ use color_eyre::Result;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::Instant;
+use tokio::sync::mpsc;
 
 /// Pane foreground colors for selected/dimmed states.
 const PANE_FG_SELECTED: &str = "#dcdce1"; // full FROST brightness
@@ -61,6 +62,8 @@ pub struct Worktree {
     pub agent: Option<TrackedPane>,
     pub terminals: Vec<TrackedPane>,
     pub pr: Option<PrInfo>,
+    /// LLM-generated short summary of the task prompt.
+    pub summary: Option<String>,
     /// Prompt to send once the agent is ready (sent after a delay, then cleared).
     pub pending_prompt: Option<(String, Instant)>,
 }
@@ -85,6 +88,7 @@ impl Worktree {
                 .iter()
                 .map(|p| state::PaneState::new(p.pane_id.clone()))
                 .collect(),
+            summary: self.summary.clone(),
         }
     }
 
@@ -111,6 +115,7 @@ impl Worktree {
                 })
                 .collect(),
             pr: None,
+            summary: ws.summary.clone(),
             pending_prompt: None,
         }
     }
@@ -195,6 +200,8 @@ pub struct App {
     last_pr_check: Instant,
     last_inbox_check: Instant,
     last_inbox_pos: u64,
+    summary_tx: mpsc::UnboundedSender<(String, String)>,
+    summary_rx: mpsc::UnboundedReceiver<(String, String)>,
 }
 
 impl App {
@@ -208,6 +215,8 @@ impl App {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "swarm".to_string());
         let session_name = format!("swarm-{}", dir_name);
+
+        let (summary_tx, summary_rx) = mpsc::unbounded_channel();
 
         let mut app = Self {
             work_dir,
@@ -233,6 +242,8 @@ impl App {
             last_pr_check: Instant::now(),
             last_inbox_check: Instant::now(),
             last_inbox_pos: 0,
+            summary_tx,
+            summary_rx,
         };
 
         // Restore previous session
@@ -345,6 +356,7 @@ impl App {
                         agent: None,
                         terminals: Vec::new(),
                         pr: None,
+                        summary: None,
                         pending_prompt: None,
                     });
                     orphan_count += 1;
@@ -363,6 +375,14 @@ impl App {
                 self.apply_worktree_color(i);
             }
             self.update_pane_selection();
+
+            // Request summaries for worktrees that don't have one yet
+            for wt in &self.worktrees {
+                if wt.summary.is_none() && !wt.prompt.is_empty() {
+                    self.request_summary(wt.id.clone(), wt.prompt.clone());
+                }
+            }
+
             self.flash(format!(
                 "restored {} worktree{}",
                 total,
@@ -848,6 +868,7 @@ impl App {
             }),
             terminals: Vec::new(),
             pr: None,
+            summary: None,
             pending_prompt: None,
         });
 
@@ -865,6 +886,9 @@ impl App {
             let _ = tmux::select_pane(sidebar);
         }
         self.save_state();
+
+        // Request LLM-generated summary for the task prompt
+        self.request_summary(window_name.clone(), prompt.to_string());
 
         // Emit event
         let _ = ipc::emit_event(
@@ -1151,11 +1175,36 @@ impl App {
         }
     }
 
+    // ── Summary Generation ─────────────────────────────────
+
+    fn request_summary(&self, worktree_id: String, prompt: String) {
+        let tx = self.summary_tx.clone();
+        tokio::spawn(async move {
+            if let Some(summary) = generate_summary_via_claude(&prompt).await {
+                let _ = tx.send((worktree_id, summary));
+            }
+        });
+    }
+
+    fn collect_summaries(&mut self) {
+        let mut changed = false;
+        while let Ok((id, summary)) = self.summary_rx.try_recv() {
+            if let Some(wt) = self.worktrees.iter_mut().find(|w| w.id == id) {
+                wt.summary = Some(summary);
+                changed = true;
+            }
+        }
+        if changed {
+            self.save_state();
+        }
+    }
+
     // ── Tick ───────────────────────────────────────────────
 
     pub fn tick(&mut self) {
         self.tick_count += 1;
 
+        self.collect_summaries();
         self.deliver_pending_prompts();
 
         // Process inbox every 500ms
@@ -1385,4 +1434,30 @@ fn sanitize(s: &str) -> String {
         .chars()
         .take(40)
         .collect()
+}
+
+/// Generate a short task summary using the Claude CLI.
+/// Returns None if the CLI is unavailable or produces bad output.
+async fn generate_summary_via_claude(prompt: &str) -> Option<String> {
+    let output = tokio::process::Command::new("claude")
+        .args([
+            "--print",
+            &format!(
+                "Summarize this coding task in 4-6 words, lowercase, no punctuation: {}",
+                prompt
+            ),
+        ])
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() || text.len() > 80 {
+        return None;
+    }
+    Some(text)
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -236,12 +236,12 @@ fn draw_worktree_list(frame: &mut Frame, area: Rect, app: &App) {
 
     let items = build_sidebar_items(app);
 
-    // Headers are 1 line, worktree rows are 2 lines
+    // Headers are 1 line, worktree rows are 3 lines
     let mut constraints: Vec<Constraint> = items
         .iter()
         .map(|item| match item {
             SidebarItem::RepoHeader(_) => Constraint::Length(1),
-            SidebarItem::WorktreeRow(_) => Constraint::Length(2),
+            SidebarItem::WorktreeRow(_) => Constraint::Length(3),
         })
         .collect();
     constraints.push(Constraint::Min(0));
@@ -327,7 +327,7 @@ fn draw_worktree_row(frame: &mut Frame, area: Rect, wt: &Worktree, selected: boo
 
     let row_chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Length(1)])
+        .constraints([Constraint::Length(1), Constraint::Length(1), Constraint::Length(1)])
         .split(area);
 
     // Line 1: color bar + selector + status + name + indicator + PR
@@ -389,6 +389,29 @@ fn draw_worktree_row(frame: &mut Frame, area: Rect, wt: &Worktree, selected: boo
         ),
     ]);
     frame.render_widget(Paragraph::new(line2), row_chunks[1]);
+
+    // Line 3: task summary (or truncated prompt as fallback)
+    let max_summary_len = (area.width as usize).saturating_sub(3); // bar + 2 spaces
+    let (summary_text, summary_style) = if let Some(ref summary) = wt.summary {
+        (
+            truncate_str(summary, max_summary_len),
+            Style::default().fg(Color::Rgb(140, 137, 130)),
+        )
+    } else if !wt.prompt.is_empty() {
+        (
+            truncate_str(&wt.prompt, max_summary_len),
+            Style::default().fg(Color::Rgb(90, 87, 80)),
+        )
+    } else {
+        (String::new(), theme::muted())
+    };
+
+    let line3 = Line::from(vec![
+        Span::styled("\u{258c}", Style::default().fg(wt_color)),
+        Span::styled("  ", Style::default()),
+        Span::styled(summary_text, summary_style),
+    ]);
+    frame.render_widget(Paragraph::new(line3), row_chunks[2]);
 }
 
 fn draw_status_bar(frame: &mut Frame, area: Rect, app: &App) {


### PR DESCRIPTION
## Summary
- Adds a 3rd line to each sidebar worktree row showing a short (4-6 word) task summary generated via `claude --print`
- Falls back to a dimmer truncated prompt while the summary is being generated or if the Claude CLI is unavailable
- Summaries persist in `state.json` and are only re-requested on restore when missing (no redundant LLM calls)

## Test plan
- [ ] `cargo build` compiles clean
- [ ] Launch swarm, create a worktree — sidebar shows truncated prompt immediately on line 3, then updates to LLM summary after a few seconds
- [ ] Restart swarm — summaries persist from state.json (no re-generation)
- [ ] If `claude` CLI not in PATH — raw truncated prompt shown permanently, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)