### PR TITLE
Retry tiled layout on tick if select-layout fails

### DIFF
--- a/src/core/tmux.rs
+++ b/src/core/tmux.rs
@@ -688,8 +688,8 @@ pub fn apply_tiled_layout(
         .output()?;
 
     if !output.status.success() {
-        // Fall back to single-column main-vertical layout
-        return apply_layout(session_window, sidebar_width);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(eyre!("select-layout failed: {}", stderr));
     }
 
     Ok(())

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -191,6 +191,7 @@ pub struct App {
     pub tick_count: u64,
     pub sidebar_pane_id: Option<String>,
     prev_selected: Option<usize>,
+    layout_dirty: bool,
     last_refresh: Instant,
     last_pr_check: Instant,
     last_inbox_check: Instant,
@@ -229,6 +230,7 @@ impl App {
             tick_count: 0,
             sidebar_pane_id: None,
             prev_selected: None,
+            layout_dirty: false,
             last_refresh: Instant::now(),
             last_pr_check: Instant::now(),
             last_inbox_check: Instant::now(),
@@ -1158,6 +1160,14 @@ impl App {
 
         self.deliver_pending_prompts();
 
+        // Retry layout rebalance if a previous attempt failed
+        if self.layout_dirty {
+            self.try_rebalance_layout();
+            if !self.layout_dirty {
+                let _ = tmux::apply_session_style(&self.session_name);
+            }
+        }
+
         // Process inbox every 500ms
         if self.last_inbox_check.elapsed().as_millis() >= 500 {
             self.process_inbox();
@@ -1320,7 +1330,14 @@ impl App {
     }
 
     /// Rebalance tmux pane layout into a tiled grid.
-    fn rebalance_layout(&self) {
+    /// Sets `layout_dirty` so the tick handler retries if this attempt fails.
+    fn rebalance_layout(&mut self) {
+        self.layout_dirty = true;
+        self.try_rebalance_layout();
+    }
+
+    /// Attempt to apply the tiled layout. Clears `layout_dirty` on success.
+    fn try_rebalance_layout(&mut self) {
         let session_window = self.session_name.clone();
         let sidebar = self
             .sidebar_pane_id
@@ -1347,7 +1364,9 @@ impl App {
             })
             .collect();
 
-        let _ = tmux::apply_tiled_layout(&session_window, &sidebar, 38, pane_groups);
+        if tmux::apply_tiled_layout(&session_window, &sidebar, 38, pane_groups).is_ok() {
+            self.layout_dirty = false;
+        }
     }
 
     fn next_worktree_num(&self) -> usize {


### PR DESCRIPTION
## Summary
- When `select-layout` fails after pane creation (timing issue with tmux), instead of silently falling back to `main-vertical` (stacked), we now track a `layout_dirty` flag and retry the tiled layout on each tick (~100ms) until it succeeds
- Removes the lossy `main-vertical` fallback from `apply_tiled_layout` — if the custom layout fails, we return an error so the retry mechanism kicks in
- Re-applies session styling after a successful retry to keep borders/colors consistent

## Test plan
- [ ] Create two tasks and verify they appear as side-by-side vertical columns immediately (or within ~100ms)
- [ ] Verify single-task creation still works (sidebar | agent)
- [ ] Verify closing a worktree still rebalances correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)