### PR TITLE
Dim sidebar pane when not focused

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,8 +104,6 @@ async fn run_sidebar(work_dir: std::path::PathBuf, agent: String) -> Result<()> 
             app.sidebar_pane_id = get_current_pane_id();
             if let Some(ref pane_id) = app.sidebar_pane_id {
                 let _ = core::tmux::set_pane_title(pane_id, "swarm");
-                // Keep sidebar bright even when window-style defaults to dimmed
-                let _ = core::tmux::set_pane_style(pane_id, "bg=#282520,fg=#dcdce1,nodim");
             }
             app.save_state();
             tui::run(&mut app).await?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1333,12 +1333,6 @@ impl App {
     /// Update pane selection styling — dims non-selected worktrees, brightens selected.
     /// Uses delta updates when possible (only touches changed worktrees).
     fn update_pane_selection(&mut self) {
-        // Always keep sidebar pane bright (even when it loses tmux focus)
-        if let Some(ref sidebar) = self.sidebar_pane_id {
-            let bright = format!("bg={},fg={},nodim", PANE_BG_SELECTED, PANE_FG_SELECTED);
-            let _ = tmux::set_pane_style(sidebar, &bright);
-        }
-
         if self.worktrees.is_empty() {
             self.prev_selected = None;
             return;


### PR DESCRIPTION
## Summary
- Removed the per-pane tmux style override that forced the sidebar to stay bright (`nodim`) at all times
- The sidebar now follows tmux's native `window-style` / `window-active-style`, dimming when the user focuses an agent pane and brightening when they return to the sidebar
- Fixes the visual issue where both the sidebar and the active agent pane appeared bright simultaneously

## Test plan
- [ ] Launch swarm, create a worktree
- [ ] Click on the agent pane — sidebar should dim
- [ ] Click back on the sidebar — it should brighten again
- [ ] Verify selected worktree panes remain bright regardless of focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)