### PR TITLE
Hide yellow block squares on sidebar pane border

### DIFF
--- a/src/core/tmux.rs
+++ b/src/core/tmux.rs
@@ -403,8 +403,10 @@ pub fn apply_session_style(session: &str) -> Result<()> {
         .args(["set-option", "-t", session, "pane-border-status", "top"])
         .output();
     // Set pane border format: selection-aware conditional
-    // Selected panes get a full-width colored line; non-selected get a dimmed small swatch
+    // Sidebar panes (@sidebar=1) get no border title at all.
+    // Selected panes get a full-width colored line; non-selected get a dimmed small swatch.
     let border_fmt = concat!(
+        "#{?#{@sidebar},,",
         "#{?#{@selected},",
         "#[fg=#{@color}]\u{2501}\u{2501} #{pane_title} ",
         "\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}",
@@ -426,6 +428,7 @@ pub fn apply_session_style(session: &str) -> Result<()> {
         "#[default]",
         ",",
         " #[fg=#{@color}]\u{2588}\u{2588}#[default]#[fg=#5a5550] #{pane_title} #[default]}",
+        "}",
     );
     let _ = Command::new("tmux")
         .args([

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,10 @@ async fn run_sidebar(work_dir: std::path::PathBuf, agent: String) -> Result<()> 
             app.sidebar_pane_id = get_current_pane_id();
             if let Some(ref pane_id) = app.sidebar_pane_id {
                 let _ = core::tmux::set_pane_title(pane_id, "swarm");
+                // Mark as sidebar so pane-border-format renders no title for it
+                let _ = std::process::Command::new("tmux")
+                    .args(["set-option", "-p", "-t", pane_id, "@sidebar", "1"])
+                    .output();
             }
             app.save_state();
             tui::run(&mut app).await?;


### PR DESCRIPTION
## Summary
- The sidebar pane was displaying `██ swarm` in its tmux pane border title (the "full yellow square" artifact), using the same border format as agent panes
- Added a `@sidebar` tmux pane user option that the border format checks — sidebar panes now render no border title at all
- Set `@sidebar=1` on the sidebar pane during startup

## Test plan
- [ ] Launch swarm — verify no yellow block squares appear next to "swarm" in the sidebar's border
- [ ] Create a worktree — verify agent panes still show their colored border titles normally
- [ ] Restart swarm — verify the sidebar border stays clean after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)