### PR TITLE
Drop row tints, increase pane spotlight contrast

### DIFF
--- a/src/core/tmux.rs
+++ b/src/core/tmux.rs
@@ -384,14 +384,14 @@ pub fn apply_session_style(session: &str) -> Result<()> {
     let _ = Command::new("tmux")
         .args([
             "set-option", "-t", session,
-            "window-style", "bg=#1a1816,fg=#504d48,dim",
+            "window-style", "bg=#141210,fg=#3a3835,dim",
         ])
         .output();
     // Active pane (sidebar, or whichever has tmux focus) stays bright
     let _ = Command::new("tmux")
         .args([
             "set-option", "-t", session,
-            "window-active-style", "bg=#282520,fg=#dcdce1,nodim",
+            "window-active-style", "bg=#302c26,fg=#dcdce1,nodim",
         ])
         .output();
     // Padded borders for visible gaps between panes

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,8 @@ async fn run_sidebar(work_dir: std::path::PathBuf, agent: String) -> Result<()> 
                 let _ = std::process::Command::new("tmux")
                     .args(["set-option", "-p", "-t", pane_id, "@sidebar", "1"])
                     .output();
+                // Keep sidebar bright even when window-style defaults to dimmed
+                let _ = core::tmux::set_pane_style(pane_id, "bg=#302c26,fg=#dcdce1,nodim");
             }
             app.save_state();
             tui::run(&mut app).await?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -10,9 +10,9 @@ use tokio::sync::mpsc;
 
 /// Pane foreground colors for selected/dimmed states.
 const PANE_FG_SELECTED: &str = "#dcdce1"; // full FROST brightness
-const PANE_FG_DIMMED: &str = "#504d48"; // heavily dimmed
-const PANE_BG_SELECTED: &str = "#282520"; // COMB — normal brightness
-const PANE_BG_DIMMED: &str = "#1a1816"; // darkened, receded
+const PANE_FG_DIMMED: &str = "#3a3835"; // heavily muted
+const PANE_BG_SELECTED: &str = "#302c26"; // slightly brighter than COMB — spotlight
+const PANE_BG_DIMMED: &str = "#141210"; // very dark, strongly receded
 
 /// Hex colors for worktree pane border titles.
 const WORKTREE_BORDER_COLORS: &[&str] = &[

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -291,17 +291,6 @@ const SIDEBAR_COLORS: &[Color] = &[
     Color::Rgb(100, 180, 60),  // olive
 ];
 
-/// Dark tinted row backgrounds matching the pane tints.
-const ROW_BG_COLORS: &[Color] = &[
-    Color::Rgb(48, 36, 24),  // warm brown
-    Color::Rgb(24, 32, 48),  // cool blue
-    Color::Rgb(24, 48, 24),  // forest green
-    Color::Rgb(40, 24, 48),  // purple
-    Color::Rgb(24, 48, 48),  // teal
-    Color::Rgb(48, 40, 24),  // amber
-    Color::Rgb(48, 24, 40),  // rose
-    Color::Rgb(32, 48, 24),  // olive
-];
 
 fn draw_worktree_row(frame: &mut Frame, area: Rect, wt: &Worktree, selected: bool, idx: usize) {
     let status = wt.status();
@@ -315,12 +304,11 @@ fn draw_worktree_row(frame: &mut Frame, area: Rect, wt: &Worktree, selected: boo
     };
 
     let wt_color = SIDEBAR_COLORS[idx % SIDEBAR_COLORS.len()];
-    let row_bg = ROW_BG_COLORS[idx % ROW_BG_COLORS.len()];
 
     let row_style = if selected {
         Style::default().bg(Color::Rgb(58, 50, 42))
     } else {
-        Style::default().bg(row_bg)
+        Style::default().bg(theme::COMB)
     };
 
     // Background


### PR DESCRIPTION
## Summary
- Removed per-row tinted backgrounds (`ROW_BG_COLORS`) from sidebar — all non-selected rows now use uniform COMB background. The colored left bar already differentiates workers.
- Increased pane spotlight contrast: selected pane bg is brighter (`#302c26`), dimmed panes are much darker (`#141210`), making the active worktree pane stand out like a spotlight.

## Test plan
- [ ] Launch swarm with 2+ worktrees, verify sidebar rows have uniform dark background (no odd tinting on bottom row)
- [ ] Navigate j/k in sidebar, verify the selected worktree's tmux pane visibly brightens and others strongly dim
- [ ] Verify pane border title bars still highlight correctly on selection change

🤖 Generated with [Claude Code](https://claude.com/claude-code)