### PR TITLE
Show task prompt in pane border titles

### DIFF
--- a/src/core/tmux.rs
+++ b/src/core/tmux.rs
@@ -323,10 +323,15 @@ pub fn kill_pane(pane_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Set a pane's border title.
+/// Set a pane's border title and lock it so child processes cannot override it.
 pub fn set_pane_title(pane_id: &str, title: &str) -> Result<()> {
     Command::new("tmux")
         .args(["select-pane", "-t", pane_id, "-T", title])
+        .output()?;
+    // Prevent the child process (e.g. Claude Code) from overriding the title
+    // via terminal escape sequences.
+    Command::new("tmux")
+        .args(["set-option", "-p", "-t", pane_id, "allow-rename", "off"])
         .output()?;
     Ok(())
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -503,7 +503,13 @@ impl App {
             tmux::split_pane_vertical(&last_agent_pane, &dir.to_string_lossy())?
         };
 
-        let _ = tmux::set_pane_title(&pane_id, &wt_id);
+        // Set pane title to truncated prompt so it matches the sidebar
+        let pane_title = if prompt.len() > 60 {
+            format!("{}…", &prompt[..prompt.char_indices().take_while(|&(i, _)| i < 60).last().map(|(i, c)| i + c.len_utf8()).unwrap_or(60)])
+        } else {
+            prompt.clone()
+        };
+        let _ = tmux::set_pane_title(&pane_id, &pane_title);
 
         // Launch agent with prompt baked into the command
         let cmd = agent.launch_cmd_with_prompt(&prompt, true);
@@ -882,8 +888,13 @@ impl App {
             )?
         };
 
-        // Set pane title
-        let _ = tmux::set_pane_title(&pane_id, &window_name);
+        // Set pane title to truncated prompt so it matches the sidebar
+        let pane_title = if prompt.len() > 60 {
+            format!("{}…", &prompt[..prompt.char_indices().take_while(|&(i, _)| i < 60).last().map(|(i, c)| i + c.len_utf8()).unwrap_or(60)])
+        } else {
+            prompt.to_string()
+        };
+        let _ = tmux::set_pane_title(&pane_id, &pane_title);
 
         // Launch agent with prompt baked into the command
         let cmd = agent.launch_cmd_with_prompt(prompt, true);


### PR DESCRIPTION
## Summary
- Pane border titles were showing "Claude code" instead of the task description because the agent process overrides the tmux pane title via terminal escape sequences
- Set `allow-rename off` on panes after setting the title to lock it
- Changed pane titles from the generic worktree ID (e.g. "repo-1") to the truncated task prompt, matching what the sidebar displays

## Test plan
- [ ] Create a new worktree — pane border should show the task prompt, not "Claude code"
- [ ] Verify long prompts are truncated at ~60 chars with ellipsis
- [ ] Re-launch an agent (`r`) and confirm the title persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)