### PR TITLE
Make claude-tui agent persistent with session resume

### DIFF
--- a/src/agent_tui/app.rs
+++ b/src/agent_tui/app.rs
@@ -42,6 +42,8 @@ pub enum SdkEvent {
     Error(String),
     /// System message (session metadata).
     System { model: Option<String> },
+    /// Session complete, now waiting for follow-up messages.
+    SessionWaiting { session_id: String },
 }
 
 /// Current status of the agent session.
@@ -57,6 +59,8 @@ pub enum SessionStatus {
     ToolRunning,
     /// Model turn complete, waiting for user or next turn.
     Idle,
+    /// Session finished, waiting for follow-up messages.
+    Waiting,
     /// Session finished.
     Done,
     /// Session errored.
@@ -256,6 +260,13 @@ impl TuiApp {
                 } else {
                     SessionStatus::Done
                 };
+            }
+            SdkEvent::SessionWaiting { session_id } => {
+                self.session_id = Some(session_id.clone());
+                self.status = SessionStatus::Waiting;
+                self.entries.push(ConversationEntry::Status {
+                    text: "Waiting for messages... (press i to type, or use `swarm send`)".to_string(),
+                });
             }
             SdkEvent::Error(msg) => {
                 self.flush_streaming_text();

--- a/src/agent_tui/mod.rs
+++ b/src/agent_tui/mod.rs
@@ -19,6 +19,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+use crate::core::ipc;
+
 /// Arguments for the agent-tui subcommand.
 pub struct AgentTuiArgs {
     pub prompt: String,
@@ -33,19 +35,13 @@ pub async fn run(args: AgentTuiArgs) -> Result<()> {
     let (followup_tx, followup_rx) = mpsc::unbounded_channel::<String>();
 
     // Set up event logger path
-    let event_log_path = if let Some(ref wt_id) = args.worktree_id {
-        args.work_dir
-            .join(".swarm")
-            .join("agents")
-            .join(wt_id)
-            .join("events.jsonl")
-    } else {
-        args.work_dir
-            .join(".swarm")
-            .join("agents")
-            .join("default")
-            .join("events.jsonl")
-    };
+    let wt_id = args.worktree_id.clone().unwrap_or_else(|| "default".to_string());
+    let event_log_path = args
+        .work_dir
+        .join(".swarm")
+        .join("agents")
+        .join(&wt_id)
+        .join("events.jsonl");
     let logger = EventLogger::new(event_log_path.clone());
 
     // Log start
@@ -81,7 +77,14 @@ pub async fn run(args: AgentTuiArgs) -> Result<()> {
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
     terminal.clear()?;
 
-    let result = event_loop(&mut terminal, &mut app, &followup_tx).await;
+    let result = event_loop(
+        &mut terminal,
+        &mut app,
+        &followup_tx,
+        &args.work_dir,
+        args.worktree_id.as_deref(),
+    )
+    .await;
 
     disable_raw_mode()?;
     stdout().execute(LeaveAlternateScreen)?;
@@ -96,7 +99,8 @@ pub async fn run(args: AgentTuiArgs) -> Result<()> {
     result
 }
 
-/// The SDK session runner — sends prompt, drains events, accepts follow-ups.
+/// The SDK session runner — sends prompt, drains events, then loops waiting for
+/// follow-up messages and resuming the session.
 async fn run_sdk_session(
     prompt: String,
     dangerously_skip: bool,
@@ -106,10 +110,12 @@ async fn run_sdk_session(
     logger: EventLogger,
 ) -> Result<()> {
     let client = ClaudeClient::new();
+
+    // Spawn initial session
     let opts = SessionOptions {
         dangerously_skip_permissions: dangerously_skip,
         include_partial_messages: true,
-        working_dir: Some(work_dir),
+        working_dir: Some(work_dir.clone()),
         ..Default::default()
     };
 
@@ -131,51 +137,96 @@ async fn run_sdk_session(
         return Ok(());
     }
 
-    // Event draining loop — also checks for follow-up messages
+    let mut current_session_id: Option<String> = None;
+
     loop {
-        tokio::select! {
-            event_result = session.next_event() => {
-                match event_result {
-                    Ok(Some(event)) => {
-                        let is_result = event.is_result();
-                        process_sdk_event(&event, &tx, &logger);
-                        if is_result {
-                            // Session complete — wait for follow-ups
-                            wait_for_followups(&mut session, &mut followup_rx, &tx, &logger).await;
-                            break;
-                        }
-                    }
-                    Ok(None) => break,
-                    Err(e) => {
-                        let msg = format!("SDK error: {}", e);
-                        logger.log_error(&msg);
-                        let _ = tx.send(SdkEvent::Error(msg));
-                        break;
-                    }
-                }
+        // Drain events from the current session until Result
+        let got_result = drain_session_events(&mut session, &tx, &logger, &mut current_session_id).await;
+
+        if !got_result {
+            // Session ended without a Result (unexpected EOF or error) — still wait for followups
+            if current_session_id.is_none() {
+                // No session to resume, we're done
+                break;
             }
         }
+
+        // Signal the TUI that we're now waiting for messages
+        if let Some(ref sid) = current_session_id {
+            let _ = tx.send(SdkEvent::SessionWaiting {
+                session_id: sid.clone(),
+            });
+        }
+
+        // Wait for a follow-up message (from user input or agent inbox)
+        let message = match followup_rx.recv().await {
+            Some(msg) => msg,
+            None => break, // Channel closed — TUI quit
+        };
+
+        // Resume the session with the captured session_id
+        let resume_opts = SessionOptions {
+            resume: current_session_id.clone(),
+            dangerously_skip_permissions: dangerously_skip,
+            include_partial_messages: true,
+            working_dir: Some(work_dir.clone()),
+            ..Default::default()
+        };
+
+        session = match client.spawn(resume_opts).await {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("Failed to resume session: {}", e);
+                logger.log_error(&msg);
+                let _ = tx.send(SdkEvent::Error(msg));
+                // Wait for next followup to try again
+                continue;
+            }
+        };
+
+        // Send the follow-up message
+        if let Err(e) = session.send_message(&message).await {
+            let msg = format!("Failed to send message: {}", e);
+            logger.log_error(&msg);
+            let _ = tx.send(SdkEvent::Error(msg));
+            continue;
+        }
+
+        // Loop back to drain events from the resumed session
     }
 
     Ok(())
 }
 
-/// After the first turn completes, wait for follow-up messages and continue the conversation.
-async fn wait_for_followups(
-    _session: &mut apiari_claude_sdk::Session,
-    followup_rx: &mut mpsc::UnboundedReceiver<String>,
-    _tx: &mpsc::UnboundedSender<SdkEvent>,
-    _logger: &EventLogger,
-) {
-    // If the session is finished (result received), we can't send more messages
-    // to *this* session. The Claude CLI result means the conversation ended.
-    // Multi-turn is handled within a single session before result is emitted.
-    // So we just drain any pending follow-ups and ignore them.
-    //
-    // For true multi-turn, the session stays alive (no result yet) and we'd
-    // need to handle this differently. For now, this is a placeholder.
-    while let Ok(_msg) = followup_rx.try_recv() {
-        // Session already finished, can't send follow-ups
+/// Drain events from a session until a Result event or EOF.
+/// Returns true if a Result event was received.
+async fn drain_session_events(
+    session: &mut apiari_claude_sdk::Session,
+    tx: &mpsc::UnboundedSender<SdkEvent>,
+    logger: &EventLogger,
+    session_id: &mut Option<String>,
+) -> bool {
+    loop {
+        match session.next_event().await {
+            Ok(Some(event)) => {
+                let is_result = event.is_result();
+                // Capture session_id from Result
+                if let Event::Result(ref result) = event {
+                    *session_id = Some(result.session_id.clone());
+                }
+                process_sdk_event(&event, tx, logger);
+                if is_result {
+                    return true;
+                }
+            }
+            Ok(None) => return false,
+            Err(e) => {
+                let msg = format!("SDK error: {}", e);
+                logger.log_error(&msg);
+                let _ = tx.send(SdkEvent::Error(msg));
+                return false;
+            }
+        }
     }
 }
 
@@ -281,13 +332,38 @@ async fn event_loop(
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     app: &mut TuiApp,
     followup_tx: &mpsc::UnboundedSender<String>,
+    work_dir: &PathBuf,
+    worktree_id: Option<&str>,
 ) -> Result<()> {
+    // Track inbox offset for polling per-agent inbox
+    let mut inbox_offset: u64 = 0;
+    let mut inbox_poll_counter: u64 = 0;
+
     loop {
         terminal.draw(|frame| render::draw(frame, app))?;
 
         // Drain SDK events and advance animation tick
         app.drain_sdk_events();
         app.tick();
+
+        // Poll per-agent inbox every ~500ms (every 10 ticks at 50ms each)
+        inbox_poll_counter += 1;
+        if inbox_poll_counter % 10 == 0 {
+            if let Some(wt_id) = worktree_id {
+                if app.status == SessionStatus::Waiting {
+                    if let Ok((messages, new_offset)) =
+                        ipc::read_agent_inbox(work_dir, wt_id, inbox_offset)
+                    {
+                        inbox_offset = new_offset;
+                        for msg in messages {
+                            app.add_user_message(msg.message.clone());
+                            let _ = followup_tx.send(msg.message);
+                            app.auto_scroll = true;
+                        }
+                    }
+                }
+            }
+        }
 
         let poll_ms = 50;
 
@@ -306,6 +382,7 @@ async fn event_loop(
                         KeyCode::Char('i') => {
                             if app.status == SessionStatus::Done
                                 || app.status == SessionStatus::Idle
+                                || app.status == SessionStatus::Waiting
                             {
                                 app.input_mode = InputMode::Input;
                             }

--- a/src/agent_tui/render.rs
+++ b/src/agent_tui/render.rs
@@ -278,6 +278,10 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &TuiApp) {
             (s, theme::status_running())
         }
         SessionStatus::Idle => ("● idle".to_string(), theme::status_idle()),
+        SessionStatus::Waiting => {
+            let dot = if (app.tick_count / 8) % 2 == 0 { "○" } else { "●" };
+            (format!("{} waiting...", dot), theme::status_idle())
+        }
         SessionStatus::Done => {
             let s = if let Some(cost) = app.cost_usd {
                 format!("● done (${:.4})", cost)
@@ -302,7 +306,7 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &TuiApp) {
         String::new()
     };
 
-    let hint = if app.status == SessionStatus::Done || app.status == SessionStatus::Idle {
+    let hint = if app.status == SessionStatus::Done || app.status == SessionStatus::Idle || app.status == SessionStatus::Waiting {
         format!(" {}u/d:page i:input q:quit ", scroll_hint)
     } else {
         format!(" {}u/d:page q:quit ", scroll_hint)

--- a/src/core/ipc.rs
+++ b/src/core/ipc.rs
@@ -102,3 +102,42 @@ pub fn emit_event(work_dir: &Path, event: &SwarmEvent) -> Result<()> {
     writer.append(event)?;
     Ok(())
 }
+
+// ── Per-Agent Inbox ───────────────────────────────────────
+
+/// A message sent to a specific agent's inbox (used by claude-tui).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentInboxMessage {
+    pub message: String,
+    pub timestamp: DateTime<Local>,
+}
+
+fn agent_inbox_path(work_dir: &Path, worktree_id: &str) -> std::path::PathBuf {
+    work_dir
+        .join(".swarm")
+        .join("agents")
+        .join(worktree_id)
+        .join("inbox.jsonl")
+}
+
+/// Write a message to a specific agent's inbox.
+pub fn write_agent_inbox(work_dir: &Path, worktree_id: &str, message: &str) -> Result<()> {
+    let writer = JsonlWriter::<AgentInboxMessage>::new(agent_inbox_path(work_dir, worktree_id));
+    writer.append(&AgentInboxMessage {
+        message: message.to_string(),
+        timestamp: Local::now(),
+    })?;
+    Ok(())
+}
+
+/// Read new messages from an agent's inbox starting at byte offset.
+pub fn read_agent_inbox(
+    work_dir: &Path,
+    worktree_id: &str,
+    offset: u64,
+) -> Result<(Vec<AgentInboxMessage>, u64)> {
+    let path = agent_inbox_path(work_dir, worktree_id);
+    let mut reader = JsonlReader::<AgentInboxMessage>::with_offset(path, offset);
+    let messages = reader.poll()?;
+    Ok((messages, reader.offset()))
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -893,7 +893,22 @@ impl App {
         let _ = tmux::set_pane_title(&pane_id, &window_name);
 
         // Build launch command but defer sending until the shell is ready
-        let cmd = agent.launch_cmd_with_prompt(prompt, true);
+        let cmd = if agent == AgentKind::ClaudeTui {
+            // ClaudeTui needs -d (project root) and --worktree-id for inbox polling
+            use crate::core::shell::shell_quote;
+            let exe = std::env::current_exe()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "swarm".to_string());
+            format!(
+                "'{}' -d {} agent-tui --dangerously-skip-permissions --worktree-id {} {}",
+                exe,
+                shell_quote(&self.work_dir.to_string_lossy()),
+                shell_quote(&window_name),
+                shell_quote(prompt),
+            )
+        } else {
+            agent.launch_cmd_with_prompt(prompt, true)
+        };
 
         self.worktrees.push(Worktree {
             id: window_name.clone(),
@@ -1157,7 +1172,10 @@ impl App {
                     worktree, message, ..
                 } => {
                     if let Some(wt) = self.worktrees.iter().find(|w| w.id == worktree) {
-                        if let Some(ref agent) = wt.agent {
+                        if wt.agent_kind == AgentKind::ClaudeTui {
+                            // Write to per-agent inbox — the agent-tui polls this directly
+                            let _ = ipc::write_agent_inbox(&self.work_dir, &worktree, &message);
+                        } else if let Some(ref agent) = wt.agent {
                             let _ = tmux::send_keys_to_pane(&agent.pane_id, &message);
                         }
                     }


### PR DESCRIPTION
## Summary

- The claude-tui agent now stays alive after completing its initial task instead of exiting
- After the first response, it enters a polling loop that watches the worktree's per-agent inbox for new messages sent via `swarm send`
- When a new message arrives, resumes the same Claude session using `--resume <session-id>` and displays the response in the TUI
- Shows a clear pulsing "waiting..." indicator in the status bar between turns so the user knows the agent is alive but idle
- The agent only exits when explicitly closed via `swarm close` or the user presses `q`/`Ctrl+C`

## Key changes

- **`core/ipc.rs`**: Added `AgentInboxMessage` type and `read_agent_inbox`/`write_agent_inbox` functions for per-worktree agent inboxes at `.swarm/agents/<id>/inbox.jsonl`
- **`agent_tui/mod.rs`**: Refactored `run_sdk_session` into a loop that drains events, captures `session_id`, signals waiting, then resumes on follow-up. Added inbox polling to the TUI event loop
- **`agent_tui/app.rs`**: Added `SessionStatus::Waiting` and `SdkEvent::SessionWaiting` with proper state transitions
- **`agent_tui/render.rs`**: Added animated "waiting..." status bar indicator with `i:input` hint
- **`tui/app.rs`**: Routes `Send` inbox messages for ClaudeTui agents to per-agent inbox instead of tmux send-keys. Fixed launch command to pass `-d` (project root) and `--worktree-id`

## Test plan

- [ ] Launch a claude-tui agent: verify it completes initial task and shows "waiting..." status
- [ ] Press `i` in waiting state: verify follow-up input works and resumes the session
- [ ] Run `swarm send <id> "message"`: verify message is picked up and session resumes
- [ ] Verify the agent stays alive between turns (pane doesn't exit)
- [ ] Press `q` to quit: verify clean exit
- [ ] Verify regular Claude agents still work with tmux send-keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)