### PR TITLE
Replace PR detail overlay with tmux modal popup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,21 @@ enum Commands {
     },
     /// Interactive picker for new worktree (runs inside tmux popup)
     Pick,
+    /// Show PR details in a tmux popup
+    PrPopup {
+        /// PR number
+        #[arg(long)]
+        number: u64,
+        /// PR title
+        #[arg(long)]
+        title: String,
+        /// PR state (OPEN, MERGED, CLOSED)
+        #[arg(long)]
+        state: String,
+        /// PR URL
+        #[arg(long)]
+        url: String,
+    },
     /// Run the TUI-native Claude agent (launched inside a tmux pane)
     AgentTui {
         /// Task prompt
@@ -93,6 +108,17 @@ async fn main() -> Result<()> {
             let repos = core::git::detect_repos(&work_dir)?;
             tui::picker::run_picker(work_dir, repos)
         }
+        Some(Commands::PrPopup {
+            number,
+            title,
+            state,
+            url,
+        }) => tui::pr_popup::run_pr_popup(tui::pr_popup::PrPopupArgs {
+            number,
+            title,
+            state,
+            url,
+        }),
         Some(Commands::AgentTui {
             prompt,
             worktree_id,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -173,7 +173,6 @@ pub enum Mode {
     AgentSelect,
     Confirm,
     Help,
-    PrDetail,
 }
 
 /// Pending action that needs confirmation.
@@ -572,43 +571,31 @@ impl App {
             return;
         }
         let wt = &self.worktrees[self.selected];
-        if wt.pr.is_some() {
-            self.mode = Mode::PrDetail;
+        if let Some(ref pr) = wt.pr {
+            let exe = std::env::current_exe()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "swarm".to_string());
+            let cmd = format!(
+                "'{}' pr-popup --number {} --title {} --state {} --url {}",
+                exe,
+                pr.number,
+                crate::core::shell::shell_quote(&pr.title),
+                crate::core::shell::shell_quote(&pr.state),
+                crate::core::shell::shell_quote(&pr.url),
+            );
+
+            if let Err(e) = tmux::display_popup(
+                &self.session_name,
+                "60%",
+                "40%",
+                &format!(" PR #{} ", pr.number),
+                &cmd,
+            ) {
+                self.flash(format!("error: {}", e));
+            }
         } else {
             self.flash("no PR found for this worktree".to_string());
         }
-    }
-
-    pub fn open_pr_in_browser(&mut self) {
-        if let Some(ref pr) = self.worktrees.get(self.selected).and_then(|wt| wt.pr.clone()) {
-            let _ = Command::new("open").arg(&pr.url).spawn();
-            self.mode = Mode::Normal;
-        }
-    }
-
-    pub fn copy_pr_url(&mut self) {
-        if let Some(ref pr) = self.worktrees.get(self.selected).and_then(|wt| wt.pr.clone()) {
-            // Use pbcopy on macOS, xclip on Linux
-            let result = Command::new("pbcopy")
-                .stdin(std::process::Stdio::piped())
-                .spawn()
-                .and_then(|mut child| {
-                    use std::io::Write;
-                    if let Some(ref mut stdin) = child.stdin {
-                        stdin.write_all(pr.url.as_bytes())?;
-                    }
-                    child.wait()
-                });
-            self.mode = Mode::Normal;
-            match result {
-                Ok(_) => self.flash("copied to clipboard".to_string()),
-                Err(_) => self.flash("error: failed to copy".to_string()),
-            }
-        }
-    }
-
-    pub fn dismiss_pr_detail(&mut self) {
-        self.mode = Mode::Normal;
     }
 
     pub fn add_terminal_to_selected(&mut self) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod picker;
+pub mod pr_popup;
 pub mod render;
 pub mod theme;
 
@@ -109,14 +110,6 @@ async fn event_loop(
                     },
                     app::Mode::Help => match key.code {
                         KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q') => app.toggle_help(),
-                        _ => {}
-                    },
-                    app::Mode::PrDetail => match key.code {
-                        KeyCode::Char('o') | KeyCode::Enter => app.open_pr_in_browser(),
-                        KeyCode::Char('c') => app.copy_pr_url(),
-                        KeyCode::Esc | KeyCode::Char('p') | KeyCode::Char('q') => {
-                            app.dismiss_pr_detail()
-                        }
                         _ => {}
                     },
                 }

--- a/src/tui/pr_popup.rs
+++ b/src/tui/pr_popup.rs
@@ -1,0 +1,163 @@
+use color_eyre::Result;
+use crossterm::{
+    ExecutableCommand,
+    event::{self, Event, KeyCode, KeyModifiers},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Paragraph, Wrap};
+use std::io::stdout;
+use std::process::Command;
+use std::time::Duration;
+
+use super::theme;
+
+pub struct PrPopupArgs {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub url: String,
+}
+
+/// Run the PR detail popup TUI. Designed to run inside a tmux display-popup.
+pub fn run_pr_popup(args: PrPopupArgs) -> Result<()> {
+    stdout().execute(EnterAlternateScreen)?;
+    enable_raw_mode()?;
+
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+    terminal.clear()?;
+
+    let result = pr_popup_loop(&mut terminal, &args);
+
+    disable_raw_mode()?;
+    stdout().execute(LeaveAlternateScreen)?;
+
+    result
+}
+
+fn pr_popup_loop(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    args: &PrPopupArgs,
+) -> Result<()> {
+    loop {
+        terminal.draw(|frame| draw_pr_popup(frame, args))?;
+
+        if event::poll(Duration::from_millis(100))? {
+            if let Event::Key(key) = event::read()? {
+                if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c')
+                {
+                    break;
+                }
+
+                match key.code {
+                    KeyCode::Char('o') | KeyCode::Enter => {
+                        let _ = Command::new("open").arg(&args.url).spawn();
+                        break;
+                    }
+                    KeyCode::Char('c') => {
+                        let _ = Command::new("pbcopy")
+                            .stdin(std::process::Stdio::piped())
+                            .spawn()
+                            .and_then(|mut child| {
+                                use std::io::Write;
+                                if let Some(ref mut stdin) = child.stdin {
+                                    stdin.write_all(args.url.as_bytes())?;
+                                }
+                                child.wait()
+                            });
+                        break;
+                    }
+                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('p') => break,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn draw_pr_popup(frame: &mut Frame, args: &PrPopupArgs) {
+    let area = frame.area();
+    frame.render_widget(
+        Block::default().style(Style::default().bg(theme::COMB)),
+        area,
+    );
+
+    let inner = area;
+    let mut y = inner.y + 1;
+
+    // PR number header
+    let header = Line::from(vec![
+        Span::styled(format!(" PR #{}", args.number), theme::title()),
+    ]);
+    frame.render_widget(
+        Paragraph::new(header),
+        Rect::new(inner.x, y, inner.width, 1),
+    );
+    y += 2;
+
+    // PR title (wrapped)
+    let title_width = inner.width.saturating_sub(2);
+    let title_lines = wrapped_line_count(&args.title, title_width as usize).min(3) as u16;
+    frame.render_widget(
+        Paragraph::new(args.title.as_str())
+            .style(theme::text())
+            .wrap(Wrap { trim: true }),
+        Rect::new(inner.x + 1, y, title_width, title_lines),
+    );
+    y += title_lines + 1;
+
+    // State badge
+    let state_style = match args.state.as_str() {
+        "MERGED" => theme::success(),
+        "OPEN" => Style::default().fg(theme::MINT),
+        _ => theme::muted(),
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(" state  ", theme::muted()),
+            Span::styled(args.state.to_lowercase(), state_style),
+        ])),
+        Rect::new(inner.x, y, inner.width.saturating_sub(1), 1),
+    );
+    y += 2;
+
+    // URL (wrapped — the whole point of this popup)
+    let url_width = inner.width.saturating_sub(2);
+    let url_lines = wrapped_line_count(&args.url, url_width as usize).min(4) as u16;
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(&args.url, theme::accent()),
+        ]))
+        .wrap(Wrap { trim: false }),
+        Rect::new(inner.x + 1, y, url_width, url_lines),
+    );
+
+    // Hints at bottom
+    let hint = Line::from(vec![
+        Span::styled("o", theme::key_hint()),
+        Span::styled(" open  ", theme::key_desc()),
+        Span::styled("c", theme::key_hint()),
+        Span::styled(" copy  ", theme::key_desc()),
+        Span::styled("esc", theme::key_hint()),
+        Span::styled(" close", theme::key_desc()),
+    ]);
+    let hint_y = inner.y + inner.height.saturating_sub(1);
+    frame.render_widget(
+        Paragraph::new(hint),
+        Rect::new(inner.x + 1, hint_y, inner.width.saturating_sub(2), 1),
+    );
+}
+
+/// Estimate how many lines a string will occupy when wrapped to a given width.
+fn wrapped_line_count(s: &str, width: usize) -> usize {
+    if width == 0 {
+        return 1;
+    }
+    let len = s.len();
+    if len == 0 {
+        return 1;
+    }
+    (len + width - 1) / width
+}

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -29,7 +29,6 @@ pub fn draw(frame: &mut Frame, app: &App) {
         Mode::AgentSelect => draw_agent_select_overlay(frame, area, app),
         Mode::Confirm => draw_confirm_overlay(frame, area, app),
         Mode::Help => draw_help_overlay(frame, area),
-        Mode::PrDetail => draw_pr_overlay(frame, area, app),
         _ => {}
     }
 }
@@ -774,86 +773,6 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
             Rect::new(inner.x, y, inner.width, 1),
         );
     }
-}
-
-fn draw_pr_overlay(frame: &mut Frame, area: Rect, app: &App) {
-    let wt = match app.worktrees.get(app.selected) {
-        Some(wt) => wt,
-        None => return,
-    };
-    let pr = match &wt.pr {
-        Some(pr) => pr,
-        None => return,
-    };
-
-    let popup_width = (area.width).min(50);
-    let popup_height = (area.height).min(12);
-    let popup = centered_rect(popup_width, popup_height, area);
-    frame.render_widget(Clear, popup);
-
-    let title = format!(" PR #{} ", pr.number);
-    let block = Block::default()
-        .title(Span::styled(title, theme::title()))
-        .borders(Borders::ALL)
-        .border_style(theme::border_active())
-        .style(Style::default().bg(theme::COMB));
-
-    let inner = block.inner(popup);
-    frame.render_widget(block, popup);
-
-    let mut y = inner.y + 1;
-
-    // PR title (wrapped)
-    let title_area = Rect::new(inner.x + 1, y, inner.width.saturating_sub(2), 2);
-    frame.render_widget(
-        Paragraph::new(pr.title.as_str())
-            .style(theme::text())
-            .wrap(Wrap { trim: true }),
-        title_area,
-    );
-    y += 2;
-
-    // State badge
-    let state_style = match pr.state.as_str() {
-        "MERGED" => theme::success(),
-        "OPEN" => Style::default().fg(theme::MINT),
-        _ => theme::muted(),
-    };
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(" state  ", theme::muted()),
-            Span::styled(pr.state.to_lowercase(), state_style),
-        ])),
-        Rect::new(inner.x + 1, y, inner.width.saturating_sub(2), 1),
-    );
-    y += 1;
-
-    // URL (wrapped)
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(" url    ", theme::muted()),
-            Span::styled(&pr.url, theme::accent()),
-        ]))
-        .wrap(Wrap { trim: false }),
-        Rect::new(inner.x + 1, y, inner.width.saturating_sub(2), 2),
-    );
-
-    // Hints at bottom
-    let hint = Line::from(vec![
-        Span::styled("o", theme::key_hint()),
-        Span::styled(" open  ", theme::key_desc()),
-        Span::styled("c", theme::key_hint()),
-        Span::styled(" copy  ", theme::key_desc()),
-        Span::styled("esc", theme::key_hint()),
-        Span::styled(" close", theme::key_desc()),
-    ]);
-    let hint_area = Rect::new(
-        inner.x + 1,
-        inner.y + inner.height - 1,
-        inner.width.saturating_sub(2),
-        1,
-    );
-    frame.render_widget(Paragraph::new(hint), hint_area);
 }
 
 // ── Helpers ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replace the in-sidebar PR detail overlay (limited to 38-char sidebar width, causing URL truncation) with a tmux `display-popup` modal
- Add `swarm pr-popup` CLI subcommand with a dedicated mini TUI (`src/tui/pr_popup.rs`), modeled after the existing `swarm pick` popup pattern
- Popup renders at 60% terminal width / 40% height, showing full PR title, state badge, and complete URL without truncation
- Remove `Mode::PrDetail` and `draw_pr_overlay` from the sidebar TUI since the popup handles everything

## Test plan
- [ ] Build: `cargo build -p swarm`
- [ ] Tests: `cargo test -p swarm` (9/9 passing)
- [ ] Verify `p` key opens tmux popup when a worktree has a PR
- [ ] Verify `o` opens PR in browser from popup
- [ ] Verify `c` copies PR URL to clipboard from popup
- [ ] Verify `esc`/`q`/`p` dismisses the popup
- [ ] Verify full PR URL is visible (not truncated) in the popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)