### PR TITLE
Make claude-tui the default agent for swarm create

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ src/
 ## Key Concepts
 
 - **Worktree** (`tui/app.rs:Worktree`): The primary unit of work. Each has an isolated git worktree, a branch (`swarm/<sanitized-prompt>-N`), an agent pane, optional terminal panes, PR tracking info, and an LLM-generated summary.
-- **AgentKind** (`core/agent.rs`): Currently `Claude` and `Codex`. Agents launch via their CLI in a tmux pane with `--dangerously-skip-permissions` for Claude.
+- **AgentKind** (`core/agent.rs`): Currently `ClaudeTui` (default), `Claude`, and `Codex`. Agents launch via their CLI in a tmux pane with `--dangerously-skip-permissions` for Claude.
 - **Sidebar**: The TUI runs in a narrow left pane (38 chars) using `main-vertical` tmux layout. Agent panes stack vertically to its right.
 - **IPC**: External commands write JSONL to `.swarm/inbox.jsonl`, sidebar reads on 500ms tick. Events emitted to `.swarm/events.jsonl`. CLI commands auto-start the sidebar if it's not already running.
 - **State**: Persisted to `.swarm/state.json` on every mutation. Restored on restart with orphan worktree discovery.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ swarm
 # Launch with a specific directory
 swarm -d ~/projects/my-app
 
-# Use codex as default agent instead of claude
-swarm -a codex
+# Use claude (one-shot) instead of default claude-tui
+swarm -a claude
 ```
 
 ### Keyboard Shortcuts

--- a/src/core/agent.rs
+++ b/src/core/agent.rs
@@ -82,7 +82,7 @@ impl AgentKind {
 
     /// All available agents.
     pub fn all() -> Vec<Self> {
-        vec![Self::Claude, Self::Codex, Self::ClaudeTui]
+        vec![Self::ClaudeTui, Self::Claude, Self::Codex]
     }
 }
 

--- a/src/core/ipc.rs
+++ b/src/core/ipc.rs
@@ -38,7 +38,7 @@ pub enum InboxMessage {
 }
 
 fn default_agent() -> String {
-    "claude".to_string()
+    "claude-tui".to_string()
 }
 
 /// Events emitted by the sidebar for external consumers.

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ struct Cli {
     #[arg(short, long, global = true)]
     dir: Option<String>,
 
-    /// Agent to use: claude, codex, opencode
-    #[arg(short, long, default_value = "claude", global = true)]
+    /// Agent to use: claude-tui, claude, codex
+    #[arg(short, long, default_value = "claude-tui", global = true)]
     agent: String,
 
     #[command(subcommand)]
@@ -35,7 +35,7 @@ enum Commands {
         /// Task prompt
         prompt: String,
         /// Agent type
-        #[arg(long, default_value = "claude")]
+        #[arg(long, default_value = "claude-tui")]
         agent: Option<String>,
         /// Repo name (required when multiple repos detected)
         #[arg(long)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -217,7 +217,7 @@ pub struct App {
 impl App {
     pub fn new(work_dir: PathBuf, agent: String) -> Result<Self> {
         let repos = git::detect_repos(&work_dir)?;
-        let default_agent = AgentKind::from_str(&agent).unwrap_or(AgentKind::Claude);
+        let default_agent = AgentKind::from_str(&agent).unwrap_or(AgentKind::ClaudeTui);
 
         // Derive session name from dir
         let dir_name = work_dir
@@ -1146,7 +1146,7 @@ impl App {
                     start_point,
                     ..
                 } => {
-                    let agent_kind = AgentKind::from_str(&agent).unwrap_or(AgentKind::Claude);
+                    let agent_kind = AgentKind::from_str(&agent).unwrap_or(AgentKind::ClaudeTui);
                     let repo_path = match repo {
                         Some(name) => {
                             match self.repos.iter().find(|r| git::repo_name(r) == name).cloned() {


### PR DESCRIPTION
## Summary
- Changes the default agent from `claude` (one-shot CLI) to `claude-tui` (persistent TUI agent) across all entry points: global `--agent` flag, `swarm create --agent`, IPC deserialization, and fallback defaults
- Reorders `AgentKind::all()` to list `ClaudeTui` first so the interactive picker pre-selects it
- `AgentKind::Claude` remains accessible via `-a claude` or `--agent claude` for one-shot automated tasks

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 9 tests pass
- [ ] Run `swarm` and verify the agent picker defaults to "Claude TUI"
- [ ] Run `swarm create "test"` and verify it launches claude-tui
- [ ] Run `swarm -a claude create "test"` and verify it launches claude (one-shot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)