### PR TITLE
Persist PR URL in state.json so hive can include it in completion notifications

### DIFF
--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,4 +1,5 @@
 use crate::core::agent::AgentKind;
+use crate::tui::app::PrInfo;
 use chrono::{DateTime, Local};
 use color_eyre::Result;
 use serde::{Deserialize, Serialize};
@@ -32,6 +33,9 @@ pub struct WorktreeState {
     pub terminals: Vec<PaneState>,
     #[serde(default)]
     pub summary: Option<String>,
+    /// PR info (number, title, state, URL) if a PR exists for this worktree's branch.
+    #[serde(default)]
+    pub pr: Option<PrInfo>,
     /// Agent status: "running" or "done". Computed at serialization time,
     /// not persisted (defaults to "running" when loading from disk).
     #[serde(default = "default_status")]
@@ -76,4 +80,74 @@ pub fn save_state(work_dir: &Path, state: &SwarmState) -> Result<()> {
     let path = state_path(work_dir);
     apiari_common::state::save_state(&path, state)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_worktree_state(pr: Option<PrInfo>) -> WorktreeState {
+        WorktreeState {
+            id: "test-1".to_string(),
+            branch: "swarm/test-1".to_string(),
+            prompt: "fix the bug".to_string(),
+            agent_kind: AgentKind::Claude,
+            repo_path: PathBuf::from("/tmp/repo"),
+            worktree_path: PathBuf::from("/tmp/repo/.swarm/wt/test-1"),
+            created_at: Local::now(),
+            agent: Some(PaneState::new("%1".to_string())),
+            terminals: vec![],
+            summary: Some("fix bug in auth".to_string()),
+            pr,
+            status: "running".to_string(),
+        }
+    }
+
+    #[test]
+    fn worktree_with_pr_round_trips() {
+        let pr = PrInfo {
+            number: 42,
+            title: "Fix auth bug".to_string(),
+            state: "OPEN".to_string(),
+            url: "https://github.com/ApiariTools/swarm/pull/42".to_string(),
+        };
+        let ws = make_worktree_state(Some(pr));
+        let json = serde_json::to_string(&ws).expect("serialize");
+        let restored: WorktreeState = serde_json::from_str(&json).expect("deserialize");
+
+        let pr = restored.pr.expect("pr should be Some");
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.title, "Fix auth bug");
+        assert_eq!(pr.state, "OPEN");
+        assert_eq!(pr.url, "https://github.com/ApiariTools/swarm/pull/42");
+    }
+
+    #[test]
+    fn worktree_without_pr_round_trips() {
+        let ws = make_worktree_state(None);
+        let json = serde_json::to_string(&ws).expect("serialize");
+        let restored: WorktreeState = serde_json::from_str(&json).expect("deserialize");
+
+        assert!(restored.pr.is_none());
+    }
+
+    #[test]
+    fn old_state_without_pr_field_deserializes() {
+        // Simulate state.json from before the pr field existed
+        let json = r#"{
+            "id": "test-1",
+            "branch": "swarm/test-1",
+            "prompt": "fix the bug",
+            "agent_kind": "claude",
+            "repo_path": "/tmp/repo",
+            "worktree_path": "/tmp/repo/.swarm/wt/test-1",
+            "created_at": "2025-01-01T00:00:00-05:00",
+            "agent": {"pane_id": "%1"},
+            "terminals": [],
+            "summary": null,
+            "status": "running"
+        }"#;
+        let restored: WorktreeState = serde_json::from_str(json).expect("deserialize old format");
+        assert!(restored.pr.is_none());
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -43,7 +43,7 @@ pub struct TrackedPane {
 }
 
 /// PR info fetched from `gh`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PrInfo {
     pub number: u64,
     pub title: String,
@@ -91,6 +91,7 @@ impl Worktree {
                 .map(|p| state::PaneState::new(p.pane_id.clone()))
                 .collect(),
             summary: self.summary.clone(),
+            pr: self.pr.clone(),
             status: if self.agent.as_ref().is_some_and(|p| matches!(p.status, super::app::PaneStatus::Running)) {
                 "running".to_string()
             } else {
@@ -121,7 +122,7 @@ impl Worktree {
                     status: PaneStatus::Running,
                 })
                 .collect(),
-            pr: None,
+            pr: ws.pr.clone(),
             summary: ws.summary.clone(),
             pending_prompt: None,
         }
@@ -1259,12 +1260,20 @@ impl App {
                                 if state == "MERGED" && wt.pr.as_ref().map_or(true, |p| p.state != "MERGED") {
                                     merged_ids.push(wt.id.clone());
                                 }
-                                wt.pr = Some(PrInfo {
+                                let new_pr = PrInfo {
                                     number: pr["number"].as_u64().unwrap_or(0),
                                     title: pr["title"].as_str().unwrap_or("").to_string(),
                                     state,
                                     url: pr["url"].as_str().unwrap_or("").to_string(),
-                                });
+                                };
+                                let is_new = wt.pr.is_none();
+                                let state_changed = wt.pr.as_ref().is_some_and(|old| old.state != new_pr.state);
+                                if is_new {
+                                    eprintln!("[swarm] PR detected: #{} \"{}\" ({}) {}", new_pr.number, new_pr.title, new_pr.state, new_pr.url);
+                                } else if state_changed {
+                                    eprintln!("[swarm] PR updated: #{} state -> {} {}", new_pr.number, new_pr.state, new_pr.url);
+                                }
+                                wt.pr = Some(new_pr);
                                 found = true;
                                 break;
                             }
@@ -1277,6 +1286,9 @@ impl App {
                 wt.pr = None;
             }
         }
+
+        // Persist updated PR info to state.json
+        self.save_state();
 
         // Auto-close worktrees whose PRs were just merged
         for id in merged_ids {


### PR DESCRIPTION
## Summary
- Added `Serialize`/`Deserialize` derives to `PrInfo` so it persists to `state.json`
- Added `pr: Option<PrInfo>` field to `WorktreeState` with `#[serde(default)]` for backward compatibility with existing state files
- Wired `to_state()`/`from_state()` to include PR info, and `save_state()` is now called after each PR refresh cycle
- Added `eprintln!` debug logging when a PR is first detected or its state changes

## Test plan
- [x] `worktree_with_pr_round_trips` — serialize a `WorktreeState` with `PrInfo`, deserialize, verify all fields match
- [x] `worktree_without_pr_round_trips` — serialize with `pr: None`, deserialize, verify it's still `None`
- [x] `old_state_without_pr_field_deserializes` — old JSON without `pr` key deserializes correctly (backward compat)
- [x] Full `cargo test -p swarm` passes (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)