### PR TITLE
Propagate agent-tui waiting status to state.json

### DIFF
--- a/src/agent_tui/mod.rs
+++ b/src/agent_tui/mod.rs
@@ -338,6 +338,7 @@ async fn event_loop(
     // Track inbox offset for polling per-agent inbox
     let mut inbox_offset: u64 = 0;
     let mut inbox_poll_counter: u64 = 0;
+    let mut prev_status = app.status.clone();
 
     loop {
         terminal.draw(|frame| render::draw(frame, app))?;
@@ -345,6 +346,21 @@ async fn event_loop(
         // Drain SDK events and advance animation tick
         app.drain_sdk_events();
         app.tick();
+
+        // Write agent status file when SessionStatus transitions to/from Waiting
+        if app.status != prev_status {
+            if let Some(wt_id) = worktree_id {
+                let became_waiting = app.status == SessionStatus::Waiting;
+                let was_waiting = prev_status == SessionStatus::Waiting;
+                if became_waiting || was_waiting {
+                    let status_str = if became_waiting { "waiting" } else { "running" };
+                    let status_dir = work_dir.join(".swarm").join("agent-status");
+                    let _ = std::fs::create_dir_all(&status_dir);
+                    let _ = std::fs::write(status_dir.join(wt_id), status_str);
+                }
+            }
+            prev_status = app.status.clone();
+        }
 
         // Poll per-agent inbox every ~500ms (every 10 ticks at 50ms each)
         inbox_poll_counter += 1;

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -40,6 +40,11 @@ pub struct WorktreeState {
     /// not persisted (defaults to "running" when loading from disk).
     #[serde(default = "default_status")]
     pub status: String,
+    /// Claude-tui session status (e.g. "waiting", "running"). Read from
+    /// `.swarm/agent-status/<worktree_id>` so hive can detect when a
+    /// worker is waiting for input.
+    #[serde(default, skip_deserializing)]
+    pub agent_session_status: Option<String>,
 }
 
 fn default_status() -> String {
@@ -100,6 +105,7 @@ mod tests {
             summary: Some("fix bug in auth".to_string()),
             pr,
             status: "running".to_string(),
+            agent_session_status: None,
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -97,6 +97,7 @@ impl Worktree {
             } else {
                 "done".to_string()
             },
+            agent_session_status: None,
         }
     }
 
@@ -403,10 +404,24 @@ impl App {
     }
 
     pub fn save_state(&self) {
+        let mut worktree_states: Vec<state::WorktreeState> =
+            self.worktrees.iter().map(|w| w.to_state()).collect();
+
+        // Read agent session status from .swarm/agent-status/<id> files
+        let status_dir = self.work_dir.join(".swarm").join("agent-status");
+        for ws in &mut worktree_states {
+            if let Ok(contents) = std::fs::read_to_string(status_dir.join(&ws.id)) {
+                let trimmed = contents.trim();
+                if !trimmed.is_empty() {
+                    ws.agent_session_status = Some(trimmed.to_string());
+                }
+            }
+        }
+
         let swarm_state = state::SwarmState {
             session_name: self.session_name.clone(),
             sidebar_pane_id: self.sidebar_pane_id.clone(),
-            worktrees: self.worktrees.iter().map(|w| w.to_state()).collect(),
+            worktrees: worktree_states,
             last_inbox_pos: self.last_inbox_pos,
         };
 


### PR DESCRIPTION
## Summary
- Adds `agent_session_status: Option<String>` to `WorktreeState` (serialized but skipped on deserialize)
- Agent-tui writes "waiting"/"running" to `.swarm/agent-status/<worktree_id>` on `SessionStatus` transitions
- Swarm TUI reads these files in `save_state()` and populates `agent_session_status` on each `WorktreeState`
- Hive can now detect when a claude-tui worker is waiting for input by reading `agent_session_status` from state.json

## Test plan
- [ ] Launch a claude-tui worker, verify `.swarm/agent-status/<id>` file is created with "waiting" when session completes initial task
- [ ] Send a follow-up message, verify file updates to "running" then back to "waiting"
- [ ] Verify state.json includes `agent_session_status: "waiting"` for idle workers
- [ ] Verify `cargo check` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)