### PR TITLE
Open source prep: MIT license, clippy, fmt

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ApiariTools
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/agent_tui/app.rs
+++ b/src/agent_tui/app.rs
@@ -180,9 +180,8 @@ impl TuiApp {
                             Some(ConversationEntry::AssistantText { text: existing }) if existing == text
                         );
                         if !already_captured {
-                            self.entries.push(ConversationEntry::AssistantText {
-                                text: text.clone(),
-                            });
+                            self.entries
+                                .push(ConversationEntry::AssistantText { text: text.clone() });
                         }
                     }
                 }
@@ -265,7 +264,8 @@ impl TuiApp {
                 self.session_id = Some(session_id.clone());
                 self.status = SessionStatus::Waiting;
                 self.entries.push(ConversationEntry::Status {
-                    text: "Waiting for messages... (press i to type, or use `swarm send`)".to_string(),
+                    text: "Waiting for messages... (press i to type, or use `swarm send`)"
+                        .to_string(),
                 });
             }
             SdkEvent::Error(msg) => {
@@ -372,6 +372,10 @@ fn truncate_output(output: &str, max_lines: usize) -> String {
         output.to_string()
     } else {
         let kept: Vec<&str> = lines[..max_lines].to_vec();
-        format!("{}\n... ({} more lines)", kept.join("\n"), lines.len() - max_lines)
+        format!(
+            "{}\n... ({} more lines)",
+            kept.join("\n"),
+            lines.len() - max_lines
+        )
     }
 }

--- a/src/agent_tui/mod.rs
+++ b/src/agent_tui/mod.rs
@@ -2,20 +2,20 @@ pub mod app;
 pub mod events;
 pub mod render;
 
-use app::{InputMode, SdkEvent, SessionStatus, TuiApp};
 use apiari_claude_sdk::streaming::AssembledEvent;
 use apiari_claude_sdk::types::ContentBlock;
 use apiari_claude_sdk::{ClaudeClient, Event, SessionOptions};
+use app::{InputMode, SdkEvent, SessionStatus, TuiApp};
 use color_eyre::Result;
+use crossterm::ExecutableCommand;
 use crossterm::event::{self, KeyCode, KeyModifiers};
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
-use crossterm::ExecutableCommand;
 use events::EventLogger;
 use ratatui::prelude::*;
 use std::io::stdout;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -35,7 +35,10 @@ pub async fn run(args: AgentTuiArgs) -> Result<()> {
     let (followup_tx, followup_rx) = mpsc::unbounded_channel::<String>();
 
     // Set up event logger path
-    let wt_id = args.worktree_id.clone().unwrap_or_else(|| "default".to_string());
+    let wt_id = args
+        .worktree_id
+        .clone()
+        .unwrap_or_else(|| "default".to_string());
     let event_log_path = args
         .work_dir
         .join(".swarm")
@@ -54,9 +57,15 @@ pub async fn run(args: AgentTuiArgs) -> Result<()> {
     let bg_logger = EventLogger::new(event_log_path);
 
     tokio::spawn(async move {
-        if let Err(e) =
-            run_sdk_session(prompt, dangerously_skip, work_dir, sdk_tx, followup_rx, bg_logger)
-                .await
+        if let Err(e) = run_sdk_session(
+            prompt,
+            dangerously_skip,
+            work_dir,
+            sdk_tx,
+            followup_rx,
+            bg_logger,
+        )
+        .await
         {
             eprintln!("SDK session error: {}", e);
         }
@@ -141,7 +150,8 @@ async fn run_sdk_session(
 
     loop {
         // Drain events from the current session until Result
-        let got_result = drain_session_events(&mut session, &tx, &logger, &mut current_session_id).await;
+        let got_result =
+            drain_session_events(&mut session, &tx, &logger, &mut current_session_id).await;
 
         if !got_result {
             // Session ended without a Result (unexpected EOF or error) — still wait for followups
@@ -231,11 +241,7 @@ async fn drain_session_events(
 }
 
 /// Convert an SDK Event into TUI SdkEvents and forward them.
-fn process_sdk_event(
-    event: &Event,
-    tx: &mpsc::UnboundedSender<SdkEvent>,
-    logger: &EventLogger,
-) {
+fn process_sdk_event(event: &Event, tx: &mpsc::UnboundedSender<SdkEvent>, logger: &EventLogger) {
     match event {
         Event::System(sys) => {
             let model = sys
@@ -269,11 +275,7 @@ fn process_sdk_event(
                                             .unwrap_or_else(|| v.to_string())
                                     })
                                     .unwrap_or_default();
-                                logger.log_tool_result(
-                                    "",
-                                    &output,
-                                    is_error.unwrap_or(false),
-                                );
+                                logger.log_tool_result("", &output, is_error.unwrap_or(false));
                             }
                             ContentBlock::Text { text } => {
                                 logger.log_text(text);
@@ -297,8 +299,8 @@ fn process_sdk_event(
             for block in &message.message.content {
                 match block {
                     ContentBlock::ToolUse { name, input, .. } => {
-                        let input_str = serde_json::to_string(input)
-                            .unwrap_or_else(|_| input.to_string());
+                        let input_str =
+                            serde_json::to_string(input).unwrap_or_else(|_| input.to_string());
                         logger.log_tool_use(name, &input_str);
                     }
                     ContentBlock::Text { text } => {
@@ -332,7 +334,7 @@ async fn event_loop(
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     app: &mut TuiApp,
     followup_tx: &mpsc::UnboundedSender<String>,
-    work_dir: &PathBuf,
+    work_dir: &Path,
     worktree_id: Option<&str>,
 ) -> Result<()> {
     // Track inbox offset for polling per-agent inbox
@@ -364,78 +366,72 @@ async fn event_loop(
 
         // Poll per-agent inbox every ~500ms (every 10 ticks at 50ms each)
         inbox_poll_counter += 1;
-        if inbox_poll_counter % 10 == 0 {
-            if let Some(wt_id) = worktree_id {
-                if app.status == SessionStatus::Waiting {
-                    if let Ok((messages, new_offset)) =
-                        ipc::read_agent_inbox(work_dir, wt_id, inbox_offset)
-                    {
-                        inbox_offset = new_offset;
-                        for msg in messages {
-                            app.add_user_message(msg.message.clone());
-                            let _ = followup_tx.send(msg.message);
-                            app.auto_scroll = true;
-                        }
-                    }
-                }
+        if inbox_poll_counter.is_multiple_of(10)
+            && let Some(wt_id) = worktree_id
+            && app.status == SessionStatus::Waiting
+            && let Ok((messages, new_offset)) = ipc::read_agent_inbox(work_dir, wt_id, inbox_offset)
+        {
+            inbox_offset = new_offset;
+            for msg in messages {
+                app.add_user_message(msg.message.clone());
+                let _ = followup_tx.send(msg.message);
+                app.auto_scroll = true;
             }
         }
 
         let poll_ms = 50;
 
-        if event::poll(Duration::from_millis(poll_ms))? {
-            if let event::Event::Key(key) = event::read()? {
-                // Ctrl+C always quits
-                if key.modifiers.contains(KeyModifiers::CONTROL)
-                    && key.code == KeyCode::Char('c')
-                {
-                    break;
-                }
+        if event::poll(Duration::from_millis(poll_ms))?
+            && let event::Event::Key(key) = event::read()?
+        {
+            // Ctrl+C always quits
+            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+                break;
+            }
 
-                match app.input_mode {
-                    InputMode::Normal => match key.code {
-                        KeyCode::Char('q') => break,
-                        KeyCode::Char('i') => {
-                            if app.status == SessionStatus::Done
-                                || app.status == SessionStatus::Idle
-                                || app.status == SessionStatus::Waiting
-                            {
-                                app.input_mode = InputMode::Input;
-                            }
+            match app.input_mode {
+                InputMode::Normal => match key.code {
+                    KeyCode::Char('q') => break,
+                    KeyCode::Char('i') => {
+                        if app.status == SessionStatus::Done
+                            || app.status == SessionStatus::Idle
+                            || app.status == SessionStatus::Waiting
+                        {
+                            app.input_mode = InputMode::Input;
                         }
-                        KeyCode::PageUp | KeyCode::Char('u') => {
-                            app.scroll_up(app.viewport_height.saturating_sub(2));
+                    }
+                    KeyCode::PageUp | KeyCode::Char('u') => {
+                        app.scroll_up(app.viewport_height.saturating_sub(2));
+                    }
+                    KeyCode::PageDown | KeyCode::Char('d') => {
+                        app.scroll_down(app.viewport_height.saturating_sub(2));
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => app.scroll_up(3),
+                    KeyCode::Down | KeyCode::Char('j') => app.scroll_down(3),
+                    KeyCode::Char('G') | KeyCode::End => app.scroll_to_bottom(),
+                    _ => {}
+                },
+                InputMode::Input => match key.code {
+                    KeyCode::Esc => {
+                        app.input_mode = InputMode::Normal;
+                        app.input_buffer.clear();
+                        app.input_cursor = 0;
+                    }
+                    KeyCode::Enter => {
+                        let text = app.take_input();
+                        if !text.trim().is_empty() {
+                            app.add_user_message(text.clone());
+                            let _ = followup_tx.send(text);
+                            app.auto_scroll = true;
                         }
-                        KeyCode::PageDown | KeyCode::Char('d') => {
-                            app.scroll_down(app.viewport_height.saturating_sub(2));
-                        }
-                        KeyCode::Up | KeyCode::Char('k') => app.scroll_up(3),
-                        KeyCode::Down | KeyCode::Char('j') => app.scroll_down(3),
-                        KeyCode::Char('G') | KeyCode::End => app.scroll_to_bottom(),
-                        _ => {}
-                    },
-                    InputMode::Input => match key.code {
-                        KeyCode::Esc => {
-                            app.input_mode = InputMode::Normal;
-                            app.input_buffer.clear();
-                            app.input_cursor = 0;
-                        }
-                        KeyCode::Enter => {
-                            let text = app.take_input();
-                            if !text.trim().is_empty() {
-                                app.add_user_message(text.clone());
-                                let _ = followup_tx.send(text);
-                                app.auto_scroll = true;
-                            }
-                            app.input_mode = InputMode::Normal;
-                        }
-                        KeyCode::Backspace => app.input_backspace(),
-                        KeyCode::Left => app.input_cursor_left(),
-                        KeyCode::Right => app.input_cursor_right(),
-                        KeyCode::Char(c) => app.input_char(c),
-                        _ => {}
-                    },
-                }
+                        app.input_mode = InputMode::Normal;
+                    }
+                    KeyCode::Backspace => app.input_backspace(),
+                    KeyCode::Left => app.input_cursor_left(),
+                    KeyCode::Right => app.input_cursor_right(),
+                    KeyCode::Char(c) => app.input_char(c),
+                    _ => {}
+                },
             }
         }
     }

--- a/src/agent_tui/render.rs
+++ b/src/agent_tui/render.rs
@@ -1,10 +1,10 @@
 use crate::agent_tui::app::{ConversationEntry, InputMode, SessionStatus, TuiApp};
 use crate::tui::theme;
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Padding, Paragraph, Wrap};
-use ratatui::Frame;
 use std::time::Duration;
 
 /// Draw the entire agent TUI.
@@ -15,8 +15,12 @@ pub fn draw(frame: &mut Frame, app: &mut TuiApp) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1), // title bar
-            Constraint::Min(1),   // conversation area
-            Constraint::Length(if app.input_mode == InputMode::Input { 3 } else { 0 }), // input area
+            Constraint::Min(1),    // conversation area
+            Constraint::Length(if app.input_mode == InputMode::Input {
+                3
+            } else {
+                0
+            }), // input area
             Constraint::Length(1), // status bar
         ])
         .split(area);
@@ -33,9 +37,7 @@ pub fn draw(frame: &mut Frame, app: &mut TuiApp) {
 }
 
 fn draw_title_bar(frame: &mut Frame, area: Rect) {
-    let title = Line::from(vec![
-        Span::styled("  Claude TUI Agent", theme::title()),
-    ]);
+    let title = Line::from(vec![Span::styled("  Claude TUI Agent", theme::title())]);
     frame.render_widget(Paragraph::new(title), area);
 }
 
@@ -63,11 +65,8 @@ fn draw_conversation(frame: &mut Frame, area: Rect, app: &TuiApp) {
             }
             ConversationEntry::AssistantText { text } => {
                 // Merge consecutive assistant text blocks under one header
-                let prev_was_assistant = i > 0
-                    && matches!(
-                        app.entries[i - 1],
-                        ConversationEntry::AssistantText { .. }
-                    );
+                let prev_was_assistant =
+                    i > 0 && matches!(app.entries[i - 1], ConversationEntry::AssistantText { .. });
                 if !prev_was_assistant {
                     lines.push(Line::from(""));
                     lines.push(Line::from(Span::styled(
@@ -130,10 +129,7 @@ fn draw_conversation(frame: &mut Frame, area: Rect, app: &TuiApp) {
                         Style::default().fg(theme::WAX),
                     )));
                     for line in out.lines().take(10) {
-                        lines.push(Line::from(Span::styled(
-                            format!("  │ {}", line),
-                            out_style,
-                        )));
+                        lines.push(Line::from(Span::styled(format!("  │ {}", line), out_style)));
                     }
                     if out.lines().count() > 10 {
                         lines.push(Line::from(Span::styled(
@@ -231,10 +227,7 @@ fn draw_input(frame: &mut Frame, area: Rect, app: &TuiApp) {
     frame.render_widget(input_text, area);
 
     // Place cursor
-    frame.set_cursor_position((
-        area.x + 2 + app.input_cursor as u16,
-        area.y + 1,
-    ));
+    frame.set_cursor_position((area.x + 2 + app.input_cursor as u16, area.y + 1));
 }
 
 fn draw_status_bar(frame: &mut Frame, area: Rect, app: &TuiApp) {
@@ -279,7 +272,11 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &TuiApp) {
         }
         SessionStatus::Idle => ("● idle".to_string(), theme::status_idle()),
         SessionStatus::Waiting => {
-            let dot = if (app.tick_count / 8) % 2 == 0 { "○" } else { "●" };
+            let dot = if (app.tick_count / 8).is_multiple_of(2) {
+                "○"
+            } else {
+                "●"
+            };
             (format!("{} waiting...", dot), theme::status_idle())
         }
         SessionStatus::Done => {
@@ -306,7 +303,10 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &TuiApp) {
         String::new()
     };
 
-    let hint = if app.status == SessionStatus::Done || app.status == SessionStatus::Idle || app.status == SessionStatus::Waiting {
+    let hint = if app.status == SessionStatus::Done
+        || app.status == SessionStatus::Idle
+        || app.status == SessionStatus::Waiting
+    {
         format!(" {}u/d:page i:input q:quit ", scroll_hint)
     } else {
         format!(" {}u/d:page q:quit ", scroll_hint)

--- a/src/core/ipc.rs
+++ b/src/core/ipc.rs
@@ -262,7 +262,6 @@ pub fn read_agent_inbox(
     Ok((messages, reader.offset()))
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,7 +281,12 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let restored: InboxMessage = serde_json::from_str(&json).unwrap();
         match restored {
-            InboxMessage::Create { prompt, agent, repo, .. } => {
+            InboxMessage::Create {
+                prompt,
+                agent,
+                repo,
+                ..
+            } => {
                 assert_eq!(prompt, "fix the login bug");
                 assert_eq!(agent, "claude");
                 assert_eq!(repo, Some("swarm".to_string()));
@@ -302,7 +306,9 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let restored: InboxMessage = serde_json::from_str(&json).unwrap();
         match restored {
-            InboxMessage::Send { worktree, message, .. } => {
+            InboxMessage::Send {
+                worktree, message, ..
+            } => {
                 assert_eq!(worktree, "hive-1");
                 assert_eq!(message, "please review the PR");
             }
@@ -350,7 +356,12 @@ mod tests {
         let json = r#"{"action":"create","id":"x","prompt":"test","timestamp":"2025-01-01T00:00:00-05:00"}"#;
         let msg: InboxMessage = serde_json::from_str(json).unwrap();
         match msg {
-            InboxMessage::Create { agent, repo, start_point, .. } => {
+            InboxMessage::Create {
+                agent,
+                repo,
+                start_point,
+                ..
+            } => {
                 assert_eq!(agent, "claude-tui");
                 assert!(repo.is_none());
                 assert!(start_point.is_none());

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -9,12 +9,14 @@ use std::process::Output;
 /// **Note**: This trait is defined but not yet wired into App. Doing so
 /// requires threading the runner through App, create_worktree_with_agent,
 /// and all the tmux/git call sites -- a refactor deferred to a follow-up PR.
+#[allow(dead_code)]
 #[cfg_attr(test, mockall::automock)]
 pub trait CommandRunner: Send + Sync {
     fn run(&self, cmd: &str, args: &[String], cwd: &Path) -> std::io::Result<Output>;
 }
 
 /// Runs commands via std::process::Command (the real implementation).
+#[allow(dead_code)]
 pub struct RealCommandRunner;
 
 impl CommandRunner for RealCommandRunner {
@@ -39,10 +41,7 @@ mod tests {
             .run("echo", &args, Path::new("/tmp"))
             .expect("echo should succeed");
         assert!(output.status.success());
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout).trim(),
-            "hello"
-        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "hello");
     }
 
     #[test]
@@ -59,9 +58,7 @@ mod tests {
             });
 
         let args = vec!["status".to_string()];
-        let output = mock
-            .run("git", &args, Path::new("/tmp"))
-            .unwrap();
+        let output = mock.run("git", &args, Path::new("/tmp")).unwrap();
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("main"));
     }

--- a/src/core/tmux.rs
+++ b/src/core/tmux.rs
@@ -550,10 +550,10 @@ fn get_pane_indices(target: &str) -> Result<HashMap<String, u16>> {
     let mut map = HashMap::new();
     for line in text.lines() {
         let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() >= 2 {
-            if let Ok(idx) = parts[1].parse::<u16>() {
-                map.insert(parts[0].to_string(), idx);
-            }
+        if parts.len() >= 2
+            && let Ok(idx) = parts[1].parse::<u16>()
+        {
+            map.insert(parts[0].to_string(), idx);
         }
     }
     Ok(map)

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,13 +112,16 @@ async fn main() -> Result<()> {
             prompt_file,
             agent,
             repo,
-        }) => cmd_create(
-            work_dir,
-            prompt,
-            prompt_file,
-            agent.unwrap_or_else(|| cli.agent.clone()),
-            repo,
-        ).await,
+        }) => {
+            cmd_create(
+                work_dir,
+                prompt,
+                prompt_file,
+                agent.unwrap_or_else(|| cli.agent.clone()),
+                repo,
+            )
+            .await
+        }
         Some(Commands::Send { worktree, message }) => cmd_send(work_dir, worktree, message).await,
         Some(Commands::Close { worktree }) => cmd_close(work_dir, worktree).await,
         Some(Commands::Merge { worktree }) => cmd_merge(work_dir, worktree).await,
@@ -257,10 +260,10 @@ fn rebalance_session(session_name: &str) {
         .iter()
         .map(|wt| {
             let mut panes = Vec::new();
-            if let Some(ref agent) = wt.agent {
-                if live_panes.contains(&agent.pane_id) {
-                    panes.push(agent.pane_id.clone());
-                }
+            if let Some(ref agent) = wt.agent
+                && live_panes.contains(&agent.pane_id)
+            {
+                panes.push(agent.pane_id.clone());
             }
             for term in &wt.terminals {
                 if live_panes.contains(&term.pane_id) {
@@ -374,10 +377,7 @@ fn worktree_status(wt: &core::state::WorktreeState, live_panes: &[String]) -> St
         .agent
         .as_ref()
         .is_some_and(|a| live_panes.contains(&a.pane_id));
-    let term_alive = wt
-        .terminals
-        .iter()
-        .any(|t| live_panes.contains(&t.pane_id));
+    let term_alive = wt.terminals.iter().any(|t| live_panes.contains(&t.pane_id));
     if agent_alive || term_alive {
         "running".to_string()
     } else {
@@ -401,10 +401,7 @@ fn resolve_prompt(prompt: Option<String>, prompt_file: Option<String>) -> Result
                     path.display()
                 ));
             }
-            eprintln!(
-                "[swarm] loaded prompt from file ({} bytes)",
-                content.len()
-            );
+            eprintln!("[swarm] loaded prompt from file ({} bytes)", content.len());
             Ok(content)
         }
         (Some(prompt), None) => Ok(prompt),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -55,7 +55,7 @@ impl PrInfo {
     /// Returns true when this PR just transitioned to MERGED relative to `prev`.
     /// Used to decide whether to auto-close the worktree.
     pub fn is_newly_merged(&self, prev: Option<&PrInfo>) -> bool {
-        self.state == "MERGED" && prev.map_or(true, |p| p.state != "MERGED")
+        self.state == "MERGED" && prev.is_none_or(|p| p.state != "MERGED")
     }
 }
 
@@ -102,7 +102,11 @@ impl Worktree {
                 .collect(),
             summary: self.summary.clone(),
             pr: self.pr.clone(),
-            status: if self.agent.as_ref().is_some_and(|p| matches!(p.status, super::app::PaneStatus::Running)) {
+            status: if self
+                .agent
+                .as_ref()
+                .is_some_and(|p| matches!(p.status, super::app::PaneStatus::Running))
+            {
                 "running".to_string()
             } else {
                 "done".to_string()
@@ -322,10 +326,10 @@ impl App {
                 for ws in &saved.worktrees {
                     let mut wt = Worktree::from_state(ws);
 
-                    if let Some(ref mut agent) = wt.agent {
-                        if !live_pane_ids.contains(&agent.pane_id) {
-                            agent.status = PaneStatus::Done;
-                        }
+                    if let Some(ref mut agent) = wt.agent
+                        && !live_pane_ids.contains(&agent.pane_id)
+                    {
+                        agent.status = PaneStatus::Done;
                     }
                     for term in &mut wt.terminals {
                         if !live_pane_ids.contains(&term.pane_id) {
@@ -489,14 +493,18 @@ impl App {
         let wt = &self.worktrees[idx];
 
         // If there's a live agent pane, jump to it
-        if let Some(ref agent) = wt.agent {
-            if agent.status == PaneStatus::Running {
-                let _ = tmux::select_pane(&agent.pane_id);
-                return;
-            }
+        if let Some(ref agent) = wt.agent
+            && agent.status == PaneStatus::Running
+        {
+            let _ = tmux::select_pane(&agent.pane_id);
+            return;
         }
         // If there's a live terminal pane, jump to it
-        if let Some(term) = wt.terminals.iter().find(|t| t.status == PaneStatus::Running) {
+        if let Some(term) = wt
+            .terminals
+            .iter()
+            .find(|t| t.status == PaneStatus::Running)
+        {
             let _ = tmux::select_pane(&term.pane_id);
             return;
         }
@@ -557,7 +565,15 @@ impl App {
 
         // Set pane title to truncated prompt so it matches the sidebar
         let pane_title = if prompt.len() > 60 {
-            format!("{}…", &prompt[..prompt.char_indices().take_while(|&(i, _)| i < 60).last().map(|(i, c)| i + c.len_utf8()).unwrap_or(60)])
+            format!(
+                "{}…",
+                &prompt[..prompt
+                    .char_indices()
+                    .take_while(|&(i, _)| i < 60)
+                    .last()
+                    .map(|(i, c)| i + c.len_utf8())
+                    .unwrap_or(60)]
+            )
         } else {
             prompt.clone()
         };
@@ -605,13 +621,7 @@ impl App {
         let dir_str = self.work_dir.to_string_lossy();
         let cmd = format!("'{}' -d '{}' pick", exe, dir_str);
 
-        if let Err(e) = tmux::display_popup(
-            &self.session_name,
-            "60%",
-            "50%",
-            " new task ",
-            &cmd,
-        ) {
+        if let Err(e) = tmux::display_popup(&self.session_name, "60%", "50%", " new task ", &cmd) {
             self.flash(format!("error: {}", e));
         }
     }
@@ -833,7 +843,10 @@ impl App {
         let agents = AgentKind::all();
         let agent = agents[self.agent_select_index].clone();
         let prompt = self.input_buffer.clone();
-        let repo_path = self.repos.get(self.repo_select_index).cloned()
+        let repo_path = self
+            .repos
+            .get(self.repo_select_index)
+            .cloned()
             .unwrap_or_else(|| self.work_dir.clone());
 
         self.mode = Mode::Normal;
@@ -845,7 +858,13 @@ impl App {
         }
     }
 
-    fn create_worktree_with_agent(&mut self, prompt: &str, agent: AgentKind, repo_path: &std::path::Path, start_point: Option<&str>) -> Result<()> {
+    fn create_worktree_with_agent(
+        &mut self,
+        prompt: &str,
+        agent: AgentKind,
+        repo_path: &std::path::Path,
+        start_point: Option<&str>,
+    ) -> Result<()> {
         self.ensure_session()?;
 
         let repo_path = repo_path.to_path_buf();
@@ -898,11 +917,7 @@ impl App {
                 .sidebar_pane_id
                 .clone()
                 .unwrap_or_else(|| "%0".to_string());
-            tmux::split_pane_horizontal(
-                &split_from,
-                &worktree_dir.to_string_lossy(),
-                70,
-            )?
+            tmux::split_pane_horizontal(&split_from, &worktree_dir.to_string_lossy(), 70)?
         } else {
             // Subsequent agents: split vertical from last live agent pane
             let last_agent_pane = self
@@ -921,15 +936,20 @@ impl App {
                         .clone()
                         .unwrap_or_else(|| "%0".to_string())
                 });
-            tmux::split_pane_vertical(
-                &last_agent_pane,
-                &worktree_dir.to_string_lossy(),
-            )?
+            tmux::split_pane_vertical(&last_agent_pane, &worktree_dir.to_string_lossy())?
         };
 
         // Set pane title to truncated prompt so it matches the sidebar
         let pane_title = if prompt.len() > 60 {
-            format!("{}…", &prompt[..prompt.char_indices().take_while(|&(i, _)| i < 60).last().map(|(i, c)| i + c.len_utf8()).unwrap_or(60)])
+            format!(
+                "{}…",
+                &prompt[..prompt
+                    .char_indices()
+                    .take_while(|&(i, _)| i < 60)
+                    .last()
+                    .map(|(i, c)| i + c.len_utf8())
+                    .unwrap_or(60)]
+            )
         } else {
             prompt.to_string()
         };
@@ -1179,52 +1199,73 @@ impl App {
                 let agent_kind = AgentKind::from_str(&agent).unwrap_or(AgentKind::ClaudeTui);
                 let repo_path = match &repo {
                     Some(name) => {
-                        match self.repos.iter().find(|r| git::repo_name(r) == *name).cloned() {
+                        match self
+                            .repos
+                            .iter()
+                            .find(|r| git::repo_name(r) == *name)
+                            .cloned()
+                        {
                             Some(path) => path,
                             None => {
-                                let names: Vec<_> = self.repos.iter().map(|r| git::repo_name(r)).collect();
+                                let names: Vec<_> =
+                                    self.repos.iter().map(|r| git::repo_name(r)).collect();
                                 let err = format!(
                                     "unknown repo '{}' (available: {})",
                                     name,
                                     names.join(", ")
                                 );
                                 self.flash(format!("create failed: {}", err));
-                                let _ = ipc::emit_event(&self.work_dir, &ipc::SwarmEvent::CreateFailed {
-                                    error: err,
-                                    prompt,
-                                    repo,
-                                    timestamp: Local::now(),
-                                });
+                                let _ = ipc::emit_event(
+                                    &self.work_dir,
+                                    &ipc::SwarmEvent::CreateFailed {
+                                        error: err,
+                                        prompt,
+                                        repo,
+                                        timestamp: Local::now(),
+                                    },
+                                );
                                 return;
                             }
                         }
                     }
                     None if self.repos.len() > 1 => {
                         let names: Vec<_> = self.repos.iter().map(|r| git::repo_name(r)).collect();
-                        let err = format!(
-                            "--repo required ({})",
-                            names.join(", ")
-                        );
+                        let err = format!("--repo required ({})", names.join(", "));
                         self.flash(format!("create failed: {}", err));
-                        let _ = ipc::emit_event(&self.work_dir, &ipc::SwarmEvent::CreateFailed {
+                        let _ = ipc::emit_event(
+                            &self.work_dir,
+                            &ipc::SwarmEvent::CreateFailed {
+                                error: err,
+                                prompt,
+                                repo,
+                                timestamp: Local::now(),
+                            },
+                        );
+                        return;
+                    }
+                    None => self
+                        .repos
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| self.work_dir.clone()),
+                };
+                if let Err(e) = self.create_worktree_with_agent(
+                    &prompt,
+                    agent_kind,
+                    &repo_path,
+                    start_point.as_deref(),
+                ) {
+                    let err = format!("{}", e);
+                    self.flash(format!("inbox create error: {}", err));
+                    let _ = ipc::emit_event(
+                        &self.work_dir,
+                        &ipc::SwarmEvent::CreateFailed {
                             error: err,
                             prompt,
                             repo,
                             timestamp: Local::now(),
-                        });
-                        return;
-                    }
-                    None => self.repos.first().cloned().unwrap_or_else(|| self.work_dir.clone()),
-                };
-                if let Err(e) = self.create_worktree_with_agent(&prompt, agent_kind, &repo_path, start_point.as_deref()) {
-                    let err = format!("{}", e);
-                    self.flash(format!("inbox create error: {}", err));
-                    let _ = ipc::emit_event(&self.work_dir, &ipc::SwarmEvent::CreateFailed {
-                        error: err,
-                        prompt,
-                        repo,
-                        timestamp: Local::now(),
-                    });
+                        },
+                    );
                 }
             }
             ipc::InboxMessage::Send {
@@ -1273,17 +1314,17 @@ impl App {
 
         // Compact the inbox once processed data exceeds 64 KB.
         let inbox_path = self.work_dir.join(".swarm").join("inbox.jsonl");
-        if self.last_inbox_pos > 64 * 1024 {
-            if let Ok(contents) = std::fs::read(&inbox_path) {
-                let pos = self.last_inbox_pos as usize;
-                let remaining = if pos < contents.len() {
-                    &contents[pos..]
-                } else {
-                    &[]
-                };
-                let _ = std::fs::write(&inbox_path, remaining);
-                self.last_inbox_pos = 0;
-            }
+        if self.last_inbox_pos > 64 * 1024
+            && let Ok(contents) = std::fs::read(&inbox_path)
+        {
+            let pos = self.last_inbox_pos as usize;
+            let remaining = if pos < contents.len() {
+                &contents[pos..]
+            } else {
+                &[]
+            };
+            let _ = std::fs::write(&inbox_path, remaining);
+            self.last_inbox_pos = 0;
         }
 
         if messages.is_empty() {
@@ -1340,7 +1381,11 @@ impl App {
                 .ok()
                 .and_then(|s| {
                     let trimmed = s.trim().to_string();
-                    if trimmed.is_empty() { None } else { Some(trimmed) }
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed)
+                    }
                 });
 
             let was_waiting = wt.agent_session_status.as_deref() == Some("waiting");
@@ -1478,11 +1523,12 @@ impl App {
 
         let mut any_done = false;
         for wt in &mut self.worktrees {
-            if let Some(ref mut agent) = wt.agent {
-                if agent.status == PaneStatus::Running && !live_pane_ids.contains(&agent.pane_id) {
-                    agent.status = PaneStatus::Done;
-                    any_done = true;
-                }
+            if let Some(ref mut agent) = wt.agent
+                && agent.status == PaneStatus::Running
+                && !live_pane_ids.contains(&agent.pane_id)
+            {
+                agent.status = PaneStatus::Done;
+                any_done = true;
             }
             for term in &mut wt.terminals {
                 if term.status == PaneStatus::Running && !live_pane_ids.contains(&term.pane_id) {
@@ -1494,16 +1540,16 @@ impl App {
         // Emit agent_done events
         if any_done {
             for wt in &self.worktrees {
-                if let Some(ref agent) = wt.agent {
-                    if agent.status == PaneStatus::Done {
-                        let _ = ipc::emit_event(
-                            &self.work_dir,
-                            &ipc::SwarmEvent::AgentDone {
-                                worktree: wt.id.clone(),
-                                timestamp: Local::now(),
-                            },
-                        );
-                    }
+                if let Some(ref agent) = wt.agent
+                    && agent.status == PaneStatus::Done
+                {
+                    let _ = ipc::emit_event(
+                        &self.work_dir,
+                        &ipc::SwarmEvent::AgentDone {
+                            worktree: wt.id.clone(),
+                            timestamp: Local::now(),
+                        },
+                    );
                 }
             }
         }
@@ -1532,10 +1578,10 @@ impl App {
     fn apply_worktree_color(&self, idx: usize) {
         let color = self.worktree_border_color(idx);
         if let Some(wt) = self.worktrees.get(idx) {
-            if let Some(ref agent) = wt.agent {
-                if agent.status == PaneStatus::Running {
-                    let _ = tmux::set_pane_color(&agent.pane_id, color);
-                }
+            if let Some(ref agent) = wt.agent
+                && agent.status == PaneStatus::Running
+            {
+                let _ = tmux::set_pane_color(&agent.pane_id, color);
             }
             for term in &wt.terminals {
                 if term.status == PaneStatus::Running {
@@ -1573,8 +1619,16 @@ impl App {
 
         for idx in indices_to_update {
             let is_selected = idx == selected;
-            let fg = if is_selected { PANE_FG_SELECTED } else { PANE_FG_DIMMED };
-            let bg = if is_selected { PANE_BG_SELECTED } else { PANE_BG_DIMMED };
+            let fg = if is_selected {
+                PANE_FG_SELECTED
+            } else {
+                PANE_FG_DIMMED
+            };
+            let bg = if is_selected {
+                PANE_BG_SELECTED
+            } else {
+                PANE_BG_DIMMED
+            };
             // Use dim/nodim attribute so colorized terminal output is also affected
             let style = if is_selected {
                 format!("bg={},fg={},nodim", bg, fg)
@@ -1583,11 +1637,11 @@ impl App {
             };
 
             if let Some(wt) = self.worktrees.get(idx) {
-                if let Some(ref agent) = wt.agent {
-                    if agent.status == PaneStatus::Running {
-                        let _ = tmux::set_pane_style(&agent.pane_id, &style);
-                        let _ = tmux::set_pane_selected(&agent.pane_id, is_selected);
-                    }
+                if let Some(ref agent) = wt.agent
+                    && agent.status == PaneStatus::Running
+                {
+                    let _ = tmux::set_pane_style(&agent.pane_id, &style);
+                    let _ = tmux::set_pane_selected(&agent.pane_id, is_selected);
                 }
                 for term in &wt.terminals {
                     if term.status == PaneStatus::Running {
@@ -1622,10 +1676,10 @@ impl App {
             .iter()
             .map(|wt| {
                 let mut panes = Vec::new();
-                if let Some(ref agent) = wt.agent {
-                    if agent.status == PaneStatus::Running {
-                        panes.push(agent.pane_id.clone());
-                    }
+                if let Some(ref agent) = wt.agent
+                    && agent.status == PaneStatus::Running
+                {
+                    panes.push(agent.pane_id.clone());
                 }
                 for term in &wt.terminals {
                     if term.status == PaneStatus::Running {
@@ -1645,7 +1699,11 @@ impl App {
         let max = self
             .worktrees
             .iter()
-            .filter_map(|w| w.id.rsplit('-').next().and_then(|n| n.parse::<usize>().ok()))
+            .filter_map(|w| {
+                w.id.rsplit('-')
+                    .next()
+                    .and_then(|n| n.parse::<usize>().ok())
+            })
             .max()
             .unwrap_or(0);
         max + 1
@@ -1702,11 +1760,18 @@ fn lookup_pr_for_worktree(wt: &mut Worktree, all_repos: &[PathBuf]) -> bool {
         .ok()
         .and_then(|o| {
             let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            if !s.is_empty() && s != wt.branch { Some(s) } else { None }
+            if !s.is_empty() && s != wt.branch {
+                Some(s)
+            } else {
+                None
+            }
         });
 
     if let Some(ref actual) = actual_branch {
-        eprintln!("[swarm] Branch fallback for {}: assigned '{}', actual '{}'", wt.id, wt.branch, actual);
+        eprintln!(
+            "[swarm] Branch fallback for {}: assigned '{}', actual '{}'",
+            wt.id, wt.branch, actual
+        );
         if let Some(newly_merged) = try_pr_lookup(wt, actual, &repo_refs, Some(actual)) {
             return newly_merged;
         }
@@ -1739,39 +1804,56 @@ fn try_pr_lookup(
     for repo_dir in repos_to_try {
         let output = Command::new("gh")
             .args([
-                "pr", "list", "--head", branch, "--state", "all",
-                "--json", "number,title,state,url", "--limit", "1",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "all",
+                "--json",
+                "number,title,state,url",
+                "--limit",
+                "1",
             ])
             .current_dir(repo_dir)
             .output();
 
-        if let Ok(output) = output {
-            if output.status.success() {
-                let text = String::from_utf8_lossy(&output.stdout);
-                if let Ok(prs) = serde_json::from_str::<Vec<serde_json::Value>>(text.trim()) {
-                    if let Some(pr) = prs.first() {
-                        let new_pr = PrInfo {
-                            number: pr["number"].as_u64().unwrap_or(0),
-                            title: pr["title"].as_str().unwrap_or("").to_string(),
-                            state: pr["state"].as_str().unwrap_or("").to_string(),
-                            url: pr["url"].as_str().unwrap_or("").to_string(),
-                        };
-                        let newly_merged = new_pr.is_newly_merged(wt.pr.as_ref());
-                        let is_new = wt.pr.is_none();
-                        let state_changed = wt.pr.as_ref().is_some_and(|old| old.state != new_pr.state);
-                        if is_new {
-                            if let Some(label) = fallback_label {
-                                eprintln!("[swarm] PR detected (via actual branch '{label}'): #{} \"{}\" ({}) {}", new_pr.number, new_pr.title, new_pr.state, new_pr.url);
-                            } else {
-                                eprintln!("[swarm] PR detected: #{} \"{}\" ({}) {}", new_pr.number, new_pr.title, new_pr.state, new_pr.url);
-                            }
-                        } else if state_changed {
-                            eprintln!("[swarm] PR updated: #{} state -> {} {}", new_pr.number, new_pr.state, new_pr.url);
-                        }
-                        wt.pr = Some(new_pr);
-                        return Some(newly_merged);
+        if let Ok(output) = output
+            && output.status.success()
+        {
+            let text = String::from_utf8_lossy(&output.stdout);
+            if let Ok(prs) = serde_json::from_str::<Vec<serde_json::Value>>(text.trim())
+                && let Some(pr) = prs.first()
+            {
+                let new_pr = PrInfo {
+                    number: pr["number"].as_u64().unwrap_or(0),
+                    title: pr["title"].as_str().unwrap_or("").to_string(),
+                    state: pr["state"].as_str().unwrap_or("").to_string(),
+                    url: pr["url"].as_str().unwrap_or("").to_string(),
+                };
+                let newly_merged = new_pr.is_newly_merged(wt.pr.as_ref());
+                let is_new = wt.pr.is_none();
+                let state_changed = wt.pr.as_ref().is_some_and(|old| old.state != new_pr.state);
+                if is_new {
+                    if let Some(label) = fallback_label {
+                        eprintln!(
+                            "[swarm] PR detected (via actual branch '{label}'): #{} \"{}\" ({}) {}",
+                            new_pr.number, new_pr.title, new_pr.state, new_pr.url
+                        );
+                    } else {
+                        eprintln!(
+                            "[swarm] PR detected: #{} \"{}\" ({}) {}",
+                            new_pr.number, new_pr.title, new_pr.state, new_pr.url
+                        );
                     }
+                } else if state_changed {
+                    eprintln!(
+                        "[swarm] PR updated: #{} state -> {} {}",
+                        new_pr.number, new_pr.state, new_pr.url
+                    );
                 }
+                wt.pr = Some(new_pr);
+                return Some(newly_merged);
             }
         }
     }
@@ -1815,41 +1897,49 @@ fn try_pr_lookup_by_worktree_branches(
     for repo_dir in repos_to_try {
         let output = Command::new("gh")
             .args([
-                "pr", "list", "--state", "all",
-                "--json", "number,title,state,url,headRefName",
-                "--limit", "20",
+                "pr",
+                "list",
+                "--state",
+                "all",
+                "--json",
+                "number,title,state,url,headRefName",
+                "--limit",
+                "20",
             ])
             .current_dir(repo_dir)
             .output();
 
-        if let Ok(output) = output {
-            if output.status.success() {
-                let text = String::from_utf8_lossy(&output.stdout);
-                if let Ok(prs) = serde_json::from_str::<Vec<serde_json::Value>>(text.trim()) {
-                    // 3. Match using the pure function
-                    if let Some(pr) = match_pr_by_local_branches(&branch_refs, &prs) {
-                        let head_ref = pr["headRefName"].as_str().unwrap_or("").to_string();
-                        let new_pr = PrInfo {
-                            number: pr["number"].as_u64().unwrap_or(0),
-                            title: pr["title"].as_str().unwrap_or("").to_string(),
-                            state: pr["state"].as_str().unwrap_or("").to_string(),
-                            url: pr["url"].as_str().unwrap_or("").to_string(),
-                        };
-                        let newly_merged = new_pr.is_newly_merged(wt.pr.as_ref());
-                        let is_new = wt.pr.is_none();
-                        let state_changed = wt.pr.as_ref().is_some_and(|old| old.state != new_pr.state);
-                        if is_new {
-                            eprintln!(
-                                "[swarm] PR detected (via worktree branch '{head_ref}'): #{} \"{}\" ({}) {}",
-                                new_pr.number, new_pr.title, new_pr.state, new_pr.url
-                            );
-                        } else if state_changed {
-                            eprintln!("[swarm] PR updated: #{} state -> {} {}", new_pr.number, new_pr.state, new_pr.url);
-                        }
-                        wt.pr = Some(new_pr);
-                        return Some(newly_merged);
-                    }
+        if let Ok(output) = output
+            && output.status.success()
+        {
+            let text = String::from_utf8_lossy(&output.stdout);
+            if let Ok(prs) = serde_json::from_str::<Vec<serde_json::Value>>(text.trim())
+                // 3. Match using the pure function
+                && let Some(pr) = match_pr_by_local_branches(&branch_refs, &prs)
+            {
+                let head_ref = pr["headRefName"].as_str().unwrap_or("").to_string();
+                let new_pr = PrInfo {
+                    number: pr["number"].as_u64().unwrap_or(0),
+                    title: pr["title"].as_str().unwrap_or("").to_string(),
+                    state: pr["state"].as_str().unwrap_or("").to_string(),
+                    url: pr["url"].as_str().unwrap_or("").to_string(),
+                };
+                let newly_merged = new_pr.is_newly_merged(wt.pr.as_ref());
+                let is_new = wt.pr.is_none();
+                let state_changed = wt.pr.as_ref().is_some_and(|old| old.state != new_pr.state);
+                if is_new {
+                    eprintln!(
+                        "[swarm] PR detected (via worktree branch '{head_ref}'): #{} \"{}\" ({}) {}",
+                        new_pr.number, new_pr.title, new_pr.state, new_pr.url
+                    );
+                } else if state_changed {
+                    eprintln!(
+                        "[swarm] PR updated: #{} state -> {} {}",
+                        new_pr.number, new_pr.state, new_pr.url
+                    );
                 }
+                wt.pr = Some(new_pr);
+                return Some(newly_merged);
             }
         }
     }
@@ -1921,7 +2011,11 @@ pub fn read_agent_status(status_dir: &std::path::Path, id: &str) -> Option<Strin
         .ok()
         .and_then(|s| {
             let trimmed = s.trim().to_string();
-            if trimmed.is_empty() { None } else { Some(trimmed) }
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
         })
 }
 
@@ -2151,7 +2245,8 @@ mod tests {
     fn strategy3_skips_empty_head_ref() {
         let prs: Vec<serde_json::Value> = serde_json::from_str(
             r#"[{"number": 1, "title": "t", "state": "OPEN", "url": "u", "headRefName": ""}]"#,
-        ).unwrap();
+        )
+        .unwrap();
         let branches = vec!["", "main"];
         let result = match_pr_by_local_branches(&branches, &prs);
         assert!(result.is_none());
@@ -2159,9 +2254,9 @@ mod tests {
 
     #[test]
     fn strategy3_skips_missing_head_ref() {
-        let prs: Vec<serde_json::Value> = serde_json::from_str(
-            r#"[{"number": 1, "title": "t", "state": "OPEN", "url": "u"}]"#,
-        ).unwrap();
+        let prs: Vec<serde_json::Value> =
+            serde_json::from_str(r#"[{"number": 1, "title": "t", "state": "OPEN", "url": "u"}]"#)
+                .unwrap();
         let branches = vec!["main"];
         let result = match_pr_by_local_branches(&branches, &prs);
         assert!(result.is_none());
@@ -2182,8 +2277,14 @@ mod tests {
         // sanitize truncates to 40 chars, then we append -1
         assert!(name.starts_with("swarm/"));
         let without_prefix = &name["swarm/".len()..];
-        let without_suffix = without_prefix.strip_suffix("-1").expect("should end with -1");
-        assert!(without_suffix.len() <= 40, "sanitized part should be <= 40 chars, got {}", without_suffix.len());
+        let without_suffix = without_prefix
+            .strip_suffix("-1")
+            .expect("should end with -1");
+        assert!(
+            without_suffix.len() <= 40,
+            "sanitized part should be <= 40 chars, got {}",
+            without_suffix.len()
+        );
     }
 
     #[test]
@@ -2225,8 +2326,12 @@ mod tests {
     #[test]
     fn test_agent_status_waiting_parsed() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("worker-1"), "waiting
-").unwrap();
+        std::fs::write(
+            dir.path().join("worker-1"),
+            "waiting
+",
+        )
+        .unwrap();
         let result = read_agent_status(dir.path(), "worker-1");
         assert_eq!(result.as_deref(), Some("waiting"));
     }
@@ -2234,8 +2339,12 @@ mod tests {
     #[test]
     fn test_agent_status_running_parsed() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("worker-1"), "running
-").unwrap();
+        std::fs::write(
+            dir.path().join("worker-1"),
+            "running
+",
+        )
+        .unwrap();
         let result = read_agent_status(dir.path(), "worker-1");
         assert_eq!(result.as_deref(), Some("running"));
     }
@@ -2243,8 +2352,12 @@ mod tests {
     #[test]
     fn test_agent_status_unknown_value_handled() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("worker-1"), "some-unknown-state
-").unwrap();
+        std::fs::write(
+            dir.path().join("worker-1"),
+            "some-unknown-state
+",
+        )
+        .unwrap();
         let result = read_agent_status(dir.path(), "worker-1");
         // Gracefully returns whatever is in the file, trimmed
         assert_eq!(result.as_deref(), Some("some-unknown-state"));
@@ -2253,8 +2366,12 @@ mod tests {
     #[test]
     fn test_agent_status_empty_file_returns_none() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("worker-1"), "  
-").unwrap();
+        std::fs::write(
+            dir.path().join("worker-1"),
+            "  
+",
+        )
+        .unwrap();
         let result = read_agent_status(dir.path(), "worker-1");
         assert!(result.is_none());
     }
@@ -2375,7 +2492,10 @@ mod tests {
         app.handle_inbox_message(msg);
 
         // Should set a flash message about the error
-        let (flash, _) = app.status_message.as_ref().expect("should have flash message");
+        let (flash, _) = app
+            .status_message
+            .as_ref()
+            .expect("should have flash message");
         assert!(flash.contains("create failed"), "flash: {}", flash);
         assert!(flash.contains("nonexistent-repo"), "flash: {}", flash);
 
@@ -2412,7 +2532,10 @@ mod tests {
         app.handle_inbox_message(msg);
 
         // Should fail with --repo required error
-        let (flash, _) = app.status_message.as_ref().expect("should have flash message");
+        let (flash, _) = app
+            .status_message
+            .as_ref()
+            .expect("should have flash message");
         assert!(flash.contains("create failed"), "flash: {}", flash);
         assert!(flash.contains("--repo required"), "flash: {}", flash);
 
@@ -2426,7 +2549,8 @@ mod tests {
         std::fs::create_dir_all(work_dir.join(".swarm")).unwrap();
 
         let mut app = test_app(work_dir.clone(), vec![]);
-        app.worktrees.push(make_test_worktree("hive-1", AgentKind::ClaudeTui));
+        app.worktrees
+            .push(make_test_worktree("hive-1", AgentKind::ClaudeTui));
 
         let msg = ipc::InboxMessage::Send {
             id: "msg-1".to_string(),
@@ -2469,8 +2593,10 @@ mod tests {
         std::fs::create_dir_all(work_dir.join(".swarm")).unwrap();
 
         let mut app = test_app(work_dir.clone(), vec![]);
-        app.worktrees.push(make_test_worktree("hive-1", AgentKind::Claude));
-        app.worktrees.push(make_test_worktree("hive-2", AgentKind::Claude));
+        app.worktrees
+            .push(make_test_worktree("hive-1", AgentKind::Claude));
+        app.worktrees
+            .push(make_test_worktree("hive-2", AgentKind::Claude));
         assert_eq!(app.worktrees.len(), 2);
 
         let msg = ipc::InboxMessage::Close {
@@ -2498,7 +2624,8 @@ mod tests {
         let work_dir = dir.path().to_path_buf();
 
         let mut app = test_app(work_dir, vec![]);
-        app.worktrees.push(make_test_worktree("hive-1", AgentKind::Claude));
+        app.worktrees
+            .push(make_test_worktree("hive-1", AgentKind::Claude));
 
         let msg = ipc::InboxMessage::Close {
             id: "msg-1".to_string(),
@@ -2535,7 +2662,8 @@ mod tests {
 
         // Dispatch through App
         let mut app = test_app(work_dir.clone(), vec![]);
-        app.worktrees.push(make_test_worktree("hive-1", AgentKind::ClaudeTui));
+        app.worktrees
+            .push(make_test_worktree("hive-1", AgentKind::ClaudeTui));
 
         for m in messages {
             app.handle_inbox_message(m);
@@ -2557,18 +2685,25 @@ mod tests {
         std::fs::create_dir_all(&status_dir).unwrap();
 
         let mut app = test_app(work_dir, vec![]);
-        app.worktrees.push(make_test_worktree("hive-1", AgentKind::ClaudeTui));
+        app.worktrees
+            .push(make_test_worktree("hive-1", AgentKind::ClaudeTui));
         assert!(app.worktrees[0].agent_session_status.is_none());
 
         // Write "running" status
         std::fs::write(status_dir.join("hive-1"), "running\n").unwrap();
         app.poll_agent_statuses();
-        assert_eq!(app.worktrees[0].agent_session_status.as_deref(), Some("running"));
+        assert_eq!(
+            app.worktrees[0].agent_session_status.as_deref(),
+            Some("running")
+        );
 
         // Transition to "waiting"
         std::fs::write(status_dir.join("hive-1"), "waiting\n").unwrap();
         app.poll_agent_statuses();
-        assert_eq!(app.worktrees[0].agent_session_status.as_deref(), Some("waiting"));
+        assert_eq!(
+            app.worktrees[0].agent_session_status.as_deref(),
+            Some("waiting")
+        );
     }
 
     #[test]
@@ -2578,7 +2713,8 @@ mod tests {
         // Don't create .swarm/agent-status — should handle gracefully
 
         let mut app = test_app(work_dir, vec![]);
-        app.worktrees.push(make_test_worktree("hive-1", AgentKind::ClaudeTui));
+        app.worktrees
+            .push(make_test_worktree("hive-1", AgentKind::ClaudeTui));
 
         // Should not panic
         app.poll_agent_statuses();
@@ -2612,7 +2748,10 @@ mod tests {
         app.poll_agent_statuses();
 
         // Status should be updated to "waiting"
-        assert_eq!(app.worktrees[0].agent_session_status.as_deref(), Some("waiting"));
+        assert_eq!(
+            app.worktrees[0].agent_session_status.as_deref(),
+            Some("waiting")
+        );
 
         // The PR lookup was attempted. Since there's no real git/gh in
         // the tempdir, lookup_pr_for_worktree will clear the PR (all
@@ -2657,5 +2796,4 @@ mod tests {
         );
         assert_eq!(app.worktrees[0].pr.as_ref().unwrap().state, "OPEN");
     }
-
 }

--- a/src/tui/picker.rs
+++ b/src/tui/picker.rs
@@ -95,123 +95,123 @@ fn picker_loop(
             continue;
         }
 
-        if event::poll(Duration::from_millis(100))? {
-            if let Event::Key(key) = event::read()? {
-                if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
-                    break;
-                }
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+        {
+            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+                break;
+            }
 
-                match picker.phase {
-                    Phase::RepoSelect => match key.code {
-                        KeyCode::Esc => break,
-                        KeyCode::Char('j') | KeyCode::Down => {
-                            picker.repo_index = (picker.repo_index + 1) % picker.repos.len();
-                        }
-                        KeyCode::Char('k') | KeyCode::Up => {
-                            picker.repo_index = if picker.repo_index == 0 {
-                                picker.repos.len() - 1
-                            } else {
-                                picker.repo_index - 1
-                            };
-                        }
-                        KeyCode::Enter => {
+            match picker.phase {
+                Phase::RepoSelect => match key.code {
+                    KeyCode::Esc => break,
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        picker.repo_index = (picker.repo_index + 1) % picker.repos.len();
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        picker.repo_index = if picker.repo_index == 0 {
+                            picker.repos.len() - 1
+                        } else {
+                            picker.repo_index - 1
+                        };
+                    }
+                    KeyCode::Enter => {
+                        picker.phase = Phase::Input;
+                    }
+                    KeyCode::Char(c @ '1'..='9') => {
+                        let idx = (c as usize) - ('1' as usize);
+                        if idx < picker.repos.len() {
+                            picker.repo_index = idx;
                             picker.phase = Phase::Input;
                         }
-                        KeyCode::Char(c @ '1'..='9') => {
-                            let idx = (c as usize) - ('1' as usize);
-                            if idx < picker.repos.len() {
-                                picker.repo_index = idx;
-                                picker.phase = Phase::Input;
-                            }
-                        }
-                        _ => {}
-                    },
-                    Phase::Input => match key.code {
-                        KeyCode::Esc => {
-                            if picker.repos.len() > 1 {
-                                picker.phase = Phase::RepoSelect;
-                                picker.input_buffer.clear();
-                                picker.input_cursor = 0;
-                            } else {
-                                break;
-                            }
-                        }
-                        KeyCode::Enter if key.modifiers.contains(KeyModifiers::ALT) => {
-                            picker.input_buffer.insert(picker.input_cursor, '\n');
-                            picker.input_cursor += 1;
-                        }
-                        KeyCode::Enter => {
-                            if !picker.input_buffer.trim().is_empty() {
-                                picker.phase = Phase::AgentSelect;
-                            }
-                        }
-                        KeyCode::Backspace => {
-                            if picker.input_cursor > 0 {
-                                picker.input_cursor -= 1;
-                                picker.input_buffer.remove(picker.input_cursor);
-                            }
-                        }
-                        KeyCode::Char(c) => {
-                            picker.input_buffer.insert(picker.input_cursor, c);
-                            picker.input_cursor += 1;
-                        }
-                        KeyCode::Left => {
-                            if picker.input_cursor > 0 {
-                                picker.input_cursor -= 1;
-                            }
-                        }
-                        KeyCode::Right => {
-                            if picker.input_cursor < picker.input_buffer.len() {
-                                picker.input_cursor += 1;
-                            }
-                        }
-                        _ => {}
-                    },
-                    Phase::AgentSelect => match key.code {
-                        KeyCode::Esc => {
-                            picker.phase = Phase::Input;
-                        }
-                        KeyCode::Char('j') | KeyCode::Down => {
-                            picker.agent_index = (picker.agent_index + 1) % AgentKind::all().len();
-                        }
-                        KeyCode::Char('k') | KeyCode::Up => {
-                            let count = AgentKind::all().len();
-                            picker.agent_index = if picker.agent_index == 0 {
-                                count - 1
-                            } else {
-                                picker.agent_index - 1
-                            };
-                        }
-                        KeyCode::Enter => {
-                            picker.phase = Phase::Fetching;
-                        }
-                        KeyCode::Char('1') => {
-                            picker.agent_index = 0;
-                            picker.phase = Phase::Fetching;
-                        }
-                        KeyCode::Char('2') => {
-                            if AgentKind::all().len() > 1 {
-                                picker.agent_index = 1;
-                                picker.phase = Phase::Fetching;
-                            }
-                        }
-                        _ => {}
-                    },
-                    Phase::FetchConfirm => match key.code {
-                        KeyCode::Char('y') | KeyCode::Enter => {
-                            picker.start_point = Some("origin/main".to_string());
-                            submit_picker(picker)?;
+                    }
+                    _ => {}
+                },
+                Phase::Input => match key.code {
+                    KeyCode::Esc => {
+                        if picker.repos.len() > 1 {
+                            picker.phase = Phase::RepoSelect;
+                            picker.input_buffer.clear();
+                            picker.input_cursor = 0;
+                        } else {
                             break;
                         }
-                        KeyCode::Char('n') | KeyCode::Esc => {
-                            picker.start_point = None;
-                            submit_picker(picker)?;
-                            break;
+                    }
+                    KeyCode::Enter if key.modifiers.contains(KeyModifiers::ALT) => {
+                        picker.input_buffer.insert(picker.input_cursor, '\n');
+                        picker.input_cursor += 1;
+                    }
+                    KeyCode::Enter => {
+                        if !picker.input_buffer.trim().is_empty() {
+                            picker.phase = Phase::AgentSelect;
                         }
-                        _ => {}
-                    },
-                    Phase::Fetching => unreachable!(),
-                }
+                    }
+                    KeyCode::Backspace => {
+                        if picker.input_cursor > 0 {
+                            picker.input_cursor -= 1;
+                            picker.input_buffer.remove(picker.input_cursor);
+                        }
+                    }
+                    KeyCode::Char(c) => {
+                        picker.input_buffer.insert(picker.input_cursor, c);
+                        picker.input_cursor += 1;
+                    }
+                    KeyCode::Left => {
+                        if picker.input_cursor > 0 {
+                            picker.input_cursor -= 1;
+                        }
+                    }
+                    KeyCode::Right => {
+                        if picker.input_cursor < picker.input_buffer.len() {
+                            picker.input_cursor += 1;
+                        }
+                    }
+                    _ => {}
+                },
+                Phase::AgentSelect => match key.code {
+                    KeyCode::Esc => {
+                        picker.phase = Phase::Input;
+                    }
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        picker.agent_index = (picker.agent_index + 1) % AgentKind::all().len();
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        let count = AgentKind::all().len();
+                        picker.agent_index = if picker.agent_index == 0 {
+                            count - 1
+                        } else {
+                            picker.agent_index - 1
+                        };
+                    }
+                    KeyCode::Enter => {
+                        picker.phase = Phase::Fetching;
+                    }
+                    KeyCode::Char('1') => {
+                        picker.agent_index = 0;
+                        picker.phase = Phase::Fetching;
+                    }
+                    KeyCode::Char('2') => {
+                        if AgentKind::all().len() > 1 {
+                            picker.agent_index = 1;
+                            picker.phase = Phase::Fetching;
+                        }
+                    }
+                    _ => {}
+                },
+                Phase::FetchConfirm => match key.code {
+                    KeyCode::Char('y') | KeyCode::Enter => {
+                        picker.start_point = Some("origin/main".to_string());
+                        submit_picker(picker)?;
+                        break;
+                    }
+                    KeyCode::Char('n') | KeyCode::Esc => {
+                        picker.start_point = None;
+                        submit_picker(picker)?;
+                        break;
+                    }
+                    _ => {}
+                },
+                Phase::Fetching => unreachable!(),
             }
         }
     }
@@ -398,7 +398,7 @@ fn draw_input_phase(frame: &mut Frame, area: Rect, picker: &Picker) {
     let mut pos = 0usize;
     for (i, line) in buf_lines.iter().enumerate() {
         let line_chars = line.chars().count();
-        if pos + line_chars >= picker.input_cursor && i <= buf_lines.len() - 1 {
+        if pos + line_chars >= picker.input_cursor && i < buf_lines.len() {
             cursor_line = i;
             cursor_col = picker.input_cursor - pos;
             break;

--- a/src/tui/pr_popup.rs
+++ b/src/tui/pr_popup.rs
@@ -42,34 +42,33 @@ fn pr_popup_loop(
     loop {
         terminal.draw(|frame| draw_pr_popup(frame, args))?;
 
-        if event::poll(Duration::from_millis(100))? {
-            if let Event::Key(key) = event::read()? {
-                if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c')
-                {
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+        {
+            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+                break;
+            }
+
+            match key.code {
+                KeyCode::Char('o') | KeyCode::Enter => {
+                    let _ = Command::new("open").arg(&args.url).spawn();
                     break;
                 }
-
-                match key.code {
-                    KeyCode::Char('o') | KeyCode::Enter => {
-                        let _ = Command::new("open").arg(&args.url).spawn();
-                        break;
-                    }
-                    KeyCode::Char('c') => {
-                        let _ = Command::new("pbcopy")
-                            .stdin(std::process::Stdio::piped())
-                            .spawn()
-                            .and_then(|mut child| {
-                                use std::io::Write;
-                                if let Some(ref mut stdin) = child.stdin {
-                                    stdin.write_all(args.url.as_bytes())?;
-                                }
-                                child.wait()
-                            });
-                        break;
-                    }
-                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('p') => break,
-                    _ => {}
+                KeyCode::Char('c') => {
+                    let _ = Command::new("pbcopy")
+                        .stdin(std::process::Stdio::piped())
+                        .spawn()
+                        .and_then(|mut child| {
+                            use std::io::Write;
+                            if let Some(ref mut stdin) = child.stdin {
+                                stdin.write_all(args.url.as_bytes())?;
+                            }
+                            child.wait()
+                        });
+                    break;
                 }
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('p') => break,
+                _ => {}
             }
         }
     }
@@ -88,9 +87,10 @@ fn draw_pr_popup(frame: &mut Frame, args: &PrPopupArgs) {
     let mut y = inner.y + 1;
 
     // PR number header
-    let header = Line::from(vec![
-        Span::styled(format!(" PR #{}", args.number), theme::title()),
-    ]);
+    let header = Line::from(vec![Span::styled(
+        format!(" PR #{}", args.number),
+        theme::title(),
+    )]);
     frame.render_widget(
         Paragraph::new(header),
         Rect::new(inner.x, y, inner.width, 1),
@@ -127,10 +127,8 @@ fn draw_pr_popup(frame: &mut Frame, args: &PrPopupArgs) {
     let url_width = inner.width.saturating_sub(2);
     let url_lines = wrapped_line_count(&args.url, url_width as usize).min(4) as u16;
     frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(&args.url, theme::accent()),
-        ]))
-        .wrap(Wrap { trim: false }),
+        Paragraph::new(Line::from(vec![Span::styled(&args.url, theme::accent())]))
+            .wrap(Wrap { trim: false }),
         Rect::new(inner.x + 1, y, url_width, url_lines),
     );
 
@@ -159,5 +157,5 @@ fn wrapped_line_count(s: &str, width: usize) -> usize {
     if len == 0 {
         return 1;
     }
-    (len + width - 1) / width
+    len.div_ceil(width)
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -14,7 +14,10 @@ pub fn draw(frame: &mut Frame, app: &App) {
     let area = frame.area();
 
     // Background
-    frame.render_widget(Block::default().style(Style::default().bg(theme::COMB)), area);
+    frame.render_widget(
+        Block::default().style(Style::default().bg(theme::COMB)),
+        area,
+    );
 
     if app.worktrees.is_empty() && app.mode == Mode::Normal {
         draw_welcome(frame, area, app);
@@ -37,7 +40,11 @@ pub fn draw(frame: &mut Frame, app: &App) {
 
 fn draw_welcome(frame: &mut Frame, area: Rect, app: &App) {
     let multi_repo = app.repos.len() > 1;
-    let repo_list_height = if multi_repo { app.repos.len() as u16 + 1 } else { 0 };
+    let repo_list_height = if multi_repo {
+        app.repos.len() as u16 + 1
+    } else {
+        0
+    };
 
     // Center content horizontally in a 44-col block
     let content_width = 44u16.min(area.width);
@@ -54,44 +61,44 @@ fn draw_welcome(frame: &mut Frame, area: Rect, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),                      // top padding
-            Constraint::Length(3),                    // header
-            Constraint::Length(1),                    // spacer
-            Constraint::Length(1),                    // tagline
-            Constraint::Length(1),                    // repo info (single) or label (multi)
-            Constraint::Length(repo_list_height),     // repo list (0 if single)
-            Constraint::Length(1),                    // spacer
-            Constraint::Length(2),                    // error
-            Constraint::Length(1),                    // spacer
-            Constraint::Length(5),                    // keys
-            Constraint::Min(1),                      // bottom padding
+            Constraint::Min(1),                   // top padding
+            Constraint::Length(3),                // header
+            Constraint::Length(1),                // spacer
+            Constraint::Length(1),                // tagline
+            Constraint::Length(1),                // repo info (single) or label (multi)
+            Constraint::Length(repo_list_height), // repo list (0 if single)
+            Constraint::Length(1),                // spacer
+            Constraint::Length(2),                // error
+            Constraint::Length(1),                // spacer
+            Constraint::Length(5),                // keys
+            Constraint::Min(1),                   // bottom padding
         ])
         .split(center);
 
     // Logo with scattered particles
     let logo = vec![
-        Line::from(vec![
-            Span::styled("     \u{00b7}  \u{00b7}     \u{00b7}", theme::muted()),
-        ]),
+        Line::from(vec![Span::styled(
+            "     \u{00b7}  \u{00b7}     \u{00b7}",
+            theme::muted(),
+        )]),
         Line::from(vec![
             Span::styled("  \u{00b7}  ", theme::muted()),
             Span::styled("s w a r m", theme::logo()),
         ]),
-        Line::from(vec![
-            Span::styled("   \u{00b7}    \u{00b7}   \u{00b7}", theme::muted()),
-        ]),
+        Line::from(vec![Span::styled(
+            "   \u{00b7}    \u{00b7}   \u{00b7}",
+            theme::muted(),
+        )]),
     ];
     frame.render_widget(Paragraph::new(logo), chunks[1]);
 
     // Tagline
-    let tagline = Paragraph::new("run agents in parallel")
-        .style(theme::muted());
+    let tagline = Paragraph::new("run agents in parallel").style(theme::muted());
     frame.render_widget(tagline, chunks[3]);
 
     if multi_repo {
         // Label
-        let label = Paragraph::new(format!("{} repos", app.repos.len()))
-            .style(theme::accent());
+        let label = Paragraph::new(format!("{} repos", app.repos.len())).style(theme::accent());
         frame.render_widget(label, chunks[4]);
 
         // Repo list
@@ -106,8 +113,7 @@ fn draw_welcome(frame: &mut Frame, area: Rect, app: &App) {
         frame.render_widget(Paragraph::new(repo_lines), chunks[5]);
     } else {
         // Single repo name
-        let repo = Paragraph::new(app.repo_display_name())
-            .style(theme::accent());
+        let repo = Paragraph::new(app.repo_display_name()).style(theme::accent());
         frame.render_widget(repo, chunks[4]);
     }
 
@@ -148,7 +154,7 @@ fn draw_sidebar(frame: &mut Frame, area: Rect, app: &App) {
         .constraints([
             Constraint::Length(2), // header
             Constraint::Length(1), // divider
-            Constraint::Min(3),   // worktree list
+            Constraint::Min(3),    // worktree list
             Constraint::Length(1), // divider
             Constraint::Length(1), // status bar
         ])
@@ -169,7 +175,10 @@ fn draw_sidebar_header(frame: &mut Frame, area: Rect, app: &App) {
         Span::styled(format!(" ({})", count), theme::muted()),
         Span::styled("  ", Style::default()),
         Span::styled(
-            truncate_str(&app.repo_display_name(), (area.width as usize).saturating_sub(16)),
+            truncate_str(
+                &app.repo_display_name(),
+                (area.width as usize).saturating_sub(16),
+            ),
             theme::accent(),
         ),
     ]);
@@ -228,8 +237,7 @@ fn build_sidebar_items(app: &App) -> Vec<SidebarItem> {
 
 fn draw_worktree_list(frame: &mut Frame, area: Rect, app: &App) {
     if app.worktrees.is_empty() {
-        let empty = Paragraph::new(" no worktrees yet\n press n to start")
-            .style(theme::muted());
+        let empty = Paragraph::new(" no worktrees yet\n press n to start").style(theme::muted());
         frame.render_widget(empty, area);
         return;
     }
@@ -337,16 +345,15 @@ fn draw_repo_header(frame: &mut Frame, area: Rect, name: &str) {
 
 /// Bright sidebar colors for the left bar indicator.
 const SIDEBAR_COLORS: &[Color] = &[
-    Color::Rgb(180, 120, 60),  // warm brown
-    Color::Rgb(60, 120, 180),  // cool blue
-    Color::Rgb(60, 180, 60),   // forest green
-    Color::Rgb(140, 60, 180),  // purple
-    Color::Rgb(60, 180, 180),  // teal
-    Color::Rgb(180, 150, 60),  // amber
-    Color::Rgb(180, 60, 120),  // rose
-    Color::Rgb(100, 180, 60),  // olive
+    Color::Rgb(180, 120, 60), // warm brown
+    Color::Rgb(60, 120, 180), // cool blue
+    Color::Rgb(60, 180, 60),  // forest green
+    Color::Rgb(140, 60, 180), // purple
+    Color::Rgb(60, 180, 180), // teal
+    Color::Rgb(180, 150, 60), // amber
+    Color::Rgb(180, 60, 120), // rose
+    Color::Rgb(100, 180, 60), // olive
 ];
-
 
 fn draw_worktree_row(frame: &mut Frame, area: Rect, wt: &Worktree, selected: bool, idx: usize) {
     let status = wt.status();
@@ -372,7 +379,11 @@ fn draw_worktree_row(frame: &mut Frame, area: Rect, wt: &Worktree, selected: boo
 
     let row_chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Length(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
         .split(area);
 
     // Line 1: color bar + selector + status + name + indicator + PR
@@ -514,7 +525,7 @@ fn draw_input_overlay(frame: &mut Frame, area: Rect, app: &App) {
     let mut pos = 0usize;
     for (i, line) in buf_lines.iter().enumerate() {
         let line_chars = line.chars().count();
-        if pos + line_chars >= app.input_cursor && i <= buf_lines.len() - 1 {
+        if pos + line_chars >= app.input_cursor && i < buf_lines.len() {
             cursor_line = i;
             cursor_col = app.input_cursor - pos;
             break;
@@ -526,7 +537,11 @@ fn draw_input_overlay(frame: &mut Frame, area: Rect, app: &App) {
     let mut styled_lines: Vec<Line> = Vec::new();
     for (i, line_str) in buf_lines.iter().enumerate() {
         let prefix = if i == 0 { " > " } else { "   " };
-        let prefix_style = if i == 0 { theme::accent() } else { theme::text() };
+        let prefix_style = if i == 0 {
+            theme::accent()
+        } else {
+            theme::text()
+        };
 
         if i == cursor_line {
             let before: String = line_str.chars().take(cursor_col).collect();
@@ -655,10 +670,7 @@ fn draw_repo_select_overlay(frame: &mut Frame, area: Rect, app: &App) {
             ),
         ]);
 
-        frame.render_widget(
-            Paragraph::new(line),
-            Rect::new(inner.x, y, inner.width, 1),
-        );
+        frame.render_widget(Paragraph::new(line), Rect::new(inner.x, y, inner.width, 1));
     }
 }
 
@@ -701,10 +713,7 @@ fn draw_agent_select_overlay(frame: &mut Frame, area: Rect, app: &App) {
             ),
         ]);
 
-        frame.render_widget(
-            Paragraph::new(line),
-            Rect::new(inner.x, y, inner.width, 1),
-        );
+        frame.render_widget(Paragraph::new(line), Rect::new(inner.x, y, inner.width, 1));
     }
 }
 
@@ -768,10 +777,7 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect) {
             Span::styled(*desc, theme::key_desc()),
         ]);
 
-        frame.render_widget(
-            Paragraph::new(line),
-            Rect::new(inner.x, y, inner.width, 1),
-        );
+        frame.render_widget(Paragraph::new(line), Rect::new(inner.x, y, inner.width, 1));
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `LICENSE` file with MIT license text
- Fix all `cargo clippy -p swarm -- -D warnings` (28 warnings across 8 files: collapsible_if, int_plus_one, manual_is_multiple_of, manual_div_ceil, ptr_arg, dead_code, unnecessary_map_or)
- Run `cargo fmt -p swarm` for consistent formatting

## Test plan
- [x] `cargo clippy -p swarm -- -D warnings` passes with zero warnings
- [x] `cargo fmt -p swarm --check` produces no changes
- [x] `cargo test -p swarm` — all 82 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)