### PR TITLE
chore: add .task/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ rust-toolchain
 # Runtime state
 .swarm/
 
+# Task artifacts (hive pipeline)
+.task/
+
 # Environment / secrets
 .env
 


### PR DESCRIPTION
## Summary
- Add `.task/` to `.gitignore` so hive pipeline task artifacts are not committed

## Test plan
- [x] Verify `.task/` directory contents are excluded from git tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)