### PR TITLE
feat: auto-pull local main branch on worktree create and close

### DIFF
--- a/src/core/git.rs
+++ b/src/core/git.rs
@@ -328,6 +328,50 @@ pub fn detect_repos(dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(repos)
 }
 
+/// Fast-forward local `main` to `origin/main`.
+///
+/// Fetches from origin, checks if main is behind, and performs a fast-forward
+/// merge if needed. All errors are logged as warnings but never propagated —
+/// this is a best-effort operation.
+pub fn pull_main(repo_path: &Path) {
+    match fetch_origin(repo_path) {
+        Ok(false) => {
+            tracing::warn!(repo = %repo_path.display(), "pull_main: fetch origin failed");
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(repo = %repo_path.display(), error = %e, "pull_main: fetch origin failed");
+            return;
+        }
+        Ok(true) => {}
+    }
+
+    let behind = match commits_behind(repo_path, "main", "origin/main") {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(error = %e, "pull_main: could not check commits behind");
+            return;
+        }
+    };
+
+    if behind == 0 {
+        tracing::debug!(repo = %repo_path.display(), "pull_main: already up to date");
+        return;
+    }
+
+    match merge_ff_only(repo_path, "origin/main") {
+        Ok(true) => {
+            tracing::info!(repo = %repo_path.display(), commits = behind, "pull_main: fast-forwarded local main");
+        }
+        Ok(false) => {
+            tracing::warn!(repo = %repo_path.display(), "pull_main: fast-forward not possible, local main may have diverged");
+        }
+        Err(e) => {
+            tracing::warn!(repo = %repo_path.display(), error = %e, "pull_main: merge failed");
+        }
+    }
+}
+
 /// Generate a `swarm/<sanitized-prompt>-<suffix>` branch name.
 pub fn generate_branch_name(prompt: &str, suffix: &str) -> String {
     format!("swarm/{}-{}", super::shell::sanitize(prompt), suffix)

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -907,6 +907,9 @@ async fn handle_request(
                 tracing::warn!(error = %e, "git fetch origin failed");
             }
 
+            // Fast-forward local main so cargo builds use fresh code
+            git::pull_main(&repo_path);
+
             // Default to origin/main when no explicit start_point
             let start_point = start_point.or_else(|| Some("origin/main".to_string()));
 
@@ -1071,6 +1074,7 @@ async fn handle_request(
 
                         let _ = git::remove_worktree(&worker.repo_path, &worker.worktree_path);
                         let _ = git::delete_branch(&worker.repo_path, &worker.branch);
+                        git::pull_main(&worker.repo_path);
 
                         let _ = ipc::emit_event(
                             &ws_path,
@@ -1128,6 +1132,7 @@ async fn handle_request(
                                 let _ =
                                     git::remove_worktree(&worker.repo_path, &worker.worktree_path);
                                 let _ = git::delete_branch(&worker.repo_path, &worker.branch);
+                                git::pull_main(&worker.repo_path);
                                 ws.workers.remove(&worktree_id);
 
                                 let _ = resp_tx.send(DaemonResponse::Ok { data: None });
@@ -1454,6 +1459,7 @@ fn apply_pr_poll_results(
                 worker.phase = WorkerPhase::Completed;
                 let _ = git::remove_worktree(&worker.repo_path, &worker.worktree_path);
                 let _ = git::delete_branch(&worker.repo_path, &worker.branch);
+                git::pull_main(&worker.repo_path);
                 let _ = ipc::emit_event(
                     &result.workspace_path,
                     &ipc::SwarmEvent::WorktreeClosed {


### PR DESCRIPTION
## Summary
- Adds `pull_main()` to `src/core/git.rs` — fetches origin, checks if local `main` is behind `origin/main`, and fast-forwards if possible (non-fatal, warns on error)
- Calls `pull_main()` on worktree **create** (after existing `fetch_origin`) so local main is fresh before branching
- Calls `pull_main()` on all three worktree **close** paths (CloseWorker, MergeWorker, auto-close on merged PR) to keep local main current

## Why
When swarm creates a worktree it fetches and branches from `origin/main`, but the local `main` branch is never updated. This means `cargo install --path ...` builds use stale code. Now local main stays current automatically.

## Test plan
- [ ] Create a worktree — verify logs show `pull_main` fast-forwarding or "already up to date"
- [ ] Close a worktree — verify same pull_main logging
- [ ] Merge a worktree — verify pull_main runs after removal
- [ ] Verify that if local main has diverged, pull_main warns but does not fail the operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)