### PR TITLE
Update README with accurate install instructions and capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,41 @@
 # swarm
 
-Run agents in parallel. Git worktrees + custom daemons + vibes.
+Run agents in parallel. Git worktrees + daemon processes + vibes.
 
-Swarm is a terminal UI that lets you run multiple AI coding agents simultaneously, each in its own isolated git worktree. Think of it as a multiplayer mode for AI-assisted development.
-
-## How it works
+Swarm is a TUI agent multiplexer — it manages multiple AI coding agents running in parallel git worktrees. Each agent gets its own isolated branch and worktree, so they never conflict.
 
 ```
 ┌──────────────┬──────────────────────────────┐
 │  swarm (3)   │  Agent 1 - "add auth"        │
-│              │  $ claude --dangerously-...   │
+│              │  ● running                    │
 │  ● add-auth  │                               │
 │  ● fix-bug   ├──────────────────────────────┤
 │  ◆ refactor  │  Agent 2 - "fix login bug"   │
-│              │  $ claude --dangerously-...   │
+│              │  ◆ waiting                    │
 │              │                               │
 │              ├──────────────────────────────┤
 │              │  Agent 3 - "refactor utils"   │
-│  n new       │  (done)                       │
+│  n new       │  ✓ done                       │
 │  t term      │                               │
 │  ↵ jump      │                               │
 │  ? help      │                               │
 └──────────────┴──────────────────────────────┘
 ```
 
-Each agent gets its own git branch and worktree, so they never conflict. When an agent finishes, merge its work back with a single keystroke.
+### What it does
+
+- Creates isolated git worktrees for parallel coding tasks
+- Spawns Claude agents in each worktree via a background daemon
+- Tracks agent status, PR URLs, and waiting/running state
+- Auto-pulls local main branch on worktree create and close
+- Auto-symlinks `.env` files (and paths listed in `.swarm/worktree-links`) into new worktrees
 
 ## Requirements
 
 - [Rust](https://rustup.rs) (for building)
-- At least one supported agent CLI:
-  - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude`)
-  - [Codex](https://github.com/openai/codex) (`codex`)
-- [GitHub CLI](https://cli.github.com) (`gh`) - optional, for PR status tracking
+- [Git](https://git-scm.com)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI (`claude`)
+- [GitHub CLI](https://cli.github.com) (`gh`) — optional, for PR status tracking
 
 ## Install
 
@@ -40,25 +43,53 @@ Each agent gets its own git branch and worktree, so they never conflict. When an
 cargo install --path .
 ```
 
-Or build manually:
+On macOS, always codesign after install:
 
 ```bash
-cargo build --release
-# Binary at target/release/swarm
+codesign -f -s - ~/.cargo/bin/swarm
 ```
 
 ## Usage
 
+### TUI
+
 ```bash
-# Launch in the current directory
-swarm
-
-# Launch with a specific directory
-swarm -d ~/projects/my-app
-
-# Use claude (one-shot) instead of default claude-tui
-swarm -a claude
+swarm                        # Launch in current directory
+swarm -d ~/projects/myapp    # Launch with a specific workspace
 ```
+
+### CLI Commands
+
+```bash
+# Spawn a new worker
+swarm create --repo my-repo --prompt-file /tmp/task.txt
+
+# Inline prompt instead of file
+swarm create --repo my-repo "add user authentication"
+
+# List all workers and their state
+swarm status
+swarm status --json          # Machine-readable output
+
+# Send a follow-up message to a running agent
+swarm send <worktree-id> "now add tests"
+
+# Merge a worktree's branch into base
+swarm merge <worktree-id>
+
+# Close and clean up a worktree
+swarm close <worktree-id>
+```
+
+Always pass `--dir <workspace-root>` or run from the workspace root.
+
+### Agents
+
+| Agent | Flag | Behavior |
+|-------|------|----------|
+| `claude-tui` (default) | _none_ | Persistent — stays alive after task, accepts follow-up messages |
+| `claude` | `--agent claude` | Autonomous — exits after completing the task |
+| `codex` | `--agent codex` | Uses OpenAI Codex in full-auto mode |
 
 ### Keyboard Shortcuts
 
@@ -73,22 +104,6 @@ swarm -a claude
 | `p` | Show PR details |
 | `?` | Toggle help |
 | `q` | Quit |
-
-### CLI Commands
-
-Swarm also supports commands for scripting and inter-process communication:
-
-```bash
-swarm status              # Show current state
-swarm status --json       # Machine-readable output
-swarm create --repo my-repo "add auth"   # Create a new worktree with an agent
-swarm send my-task "msg"  # Send a message to a running agent
-swarm merge my-task       # Merge a worktree's branch into base
-swarm close my-task       # Close and clean up a worktree
-
-# For long/multiline prompts, use --prompt-file instead of inline args:
-swarm create --repo my-repo --prompt-file /tmp/task.txt
-```
 
 ## Multi-Repo Support
 
@@ -108,17 +123,18 @@ When creating a new worktree, you'll get a repo picker before entering your task
 
 ## State & Files
 
-Swarm stores its state in a `.swarm/` directory inside your project:
+Swarm stores its state in a `.swarm/` directory inside your workspace:
 
 ```
 .swarm/
-  state.json      # Session state (survives restarts)
-  inbox.jsonl     # Incoming IPC messages
-  events.jsonl    # Event log
-  wt/             # Git worktrees
+  state.json        # Session state (survives restarts)
+  inbox.jsonl       # Incoming IPC messages
+  events.jsonl      # Event log
+  wt/               # Git worktrees
+  worktree-links    # Extra files to symlink into worktrees (one path per line)
 ```
 
-You may want to add `.swarm/` to your `.gitignore`.
+Add `.swarm/` to your `.gitignore`.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Rewrote README to reflect current architecture: daemon-based agent management (removed outdated tmux references)
- Added macOS codesign requirement after install
- Added agent types table documenting `claude-tui` (persistent), `claude` (autonomous), and `codex` modes
- Documented auto-pull on worktree create/close and `.env` symlink behavior
- Added `.swarm/worktree-links` manifest to State & Files section
- Kept existing keyboard shortcuts, multi-repo support, and merge docs

## Test plan
- [ ] Verify install instructions work: `cargo install --path .` + codesign
- [ ] Confirm CLI command examples match actual behavior
- [ ] Review agent types table for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)