### PR TITLE
feat: add crates.io publish step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,15 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ matrix.binary }}
+
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `publish` job to the release workflow that publishes to crates.io after all build matrix jobs complete
- Uses `CRATES_IO_TOKEN` secret for authentication

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Confirm the `publish` job runs after all `build` matrix jobs via `needs: [build]`
- [ ] Ensure `CRATES_IO_TOKEN` secret is configured in the repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)