### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari-swarm"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Run agents in parallel. Git worktrees + custom daemons + vibes."
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump apiari-swarm crate version from 0.1.0 to 0.1.1 in `Cargo.toml`

## Test plan
- [ ] Verify `Cargo.toml` has `version = "0.1.1"`
- [ ] After merge, tag `v0.1.1` and push the tag to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)