### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari-swarm"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 description = "Run agents in parallel. Git worktrees + custom daemons + vibes."
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump `apiari-swarm` crate version from 0.1.1 to 0.1.2

## Notes
- `cargo update` and `cargo fmt` could not run in the worktree (no workspace root access), but Cargo.lock is managed at the workspace level and will update on next build.
- After merging, tag `v0.1.2` on main to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)