### PR TITLE
feat: auto-start daemon for CLI subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -219,31 +219,8 @@ async fn run_default_tui(work_dir: std::path::PathBuf) -> Result<()> {
     }
 
     if !is_daemon_running(&work_dir) {
-        // ensure_daemon_running waits for the socket, but the TUI has its own
-        // reconnect loop so we just need to spawn — don't block on readiness.
-        eprintln!("[swarm] Starting daemon...");
-        let exe = std::env::current_exe()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| "swarm".to_string());
-
-        let log_dir = work_dir.join(".swarm");
-        std::fs::create_dir_all(&log_dir).ok();
-        let daemon_log = std::fs::File::create(log_dir.join("daemon-stderr.log"))
-            .unwrap_or_else(|_| std::fs::File::open("/dev/null").unwrap());
-
-        std::process::Command::new(&exe)
-            .args([
-                "-d",
-                &work_dir.to_string_lossy(),
-                "daemon",
-                "start",
-                "--foreground",
-            ])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::from(daemon_log))
-            .spawn()
-            .map_err(|e| color_eyre::eyre::eyre!("failed to spawn daemon: {}", e))?;
+        // TUI has its own reconnect loop, so just spawn — don't block on readiness.
+        spawn_daemon(&work_dir)?;
     } else {
         // Daemon already running — register workspace in background (don't block TUI startup)
         let bg_dir = work_dir.clone();
@@ -265,14 +242,8 @@ fn is_daemon_running(_work_dir: &std::path::Path) -> bool {
     daemon::read_global_pid().is_some_and(daemon::is_process_alive)
 }
 
-/// Ensure the daemon is running, starting it if necessary.
-/// Unlike the TUI (which has its own reconnect loop), CLI subcommands need the
-/// daemon to be accepting connections before they can proceed.
-fn ensure_daemon_running(work_dir: &std::path::Path) -> Result<()> {
-    if is_daemon_running(work_dir) {
-        return Ok(());
-    }
-
+/// Spawn the daemon process in the background. Shared by TUI and CLI paths.
+fn spawn_daemon(work_dir: &std::path::Path) -> Result<()> {
     eprintln!("[swarm] Starting daemon...");
     let exe = std::env::current_exe()
         .map(|p| p.to_string_lossy().to_string())
@@ -297,14 +268,33 @@ fn ensure_daemon_running(work_dir: &std::path::Path) -> Result<()> {
         .spawn()
         .map_err(|e| color_eyre::eyre::eyre!("failed to spawn daemon: {}", e))?;
 
+    Ok(())
+}
+
+/// Ensure the daemon is running, starting it if necessary.
+/// Waits for the daemon socket to accept connections before returning.
+async fn ensure_daemon_running(work_dir: &std::path::Path) -> Result<()> {
+    if is_daemon_running(work_dir) {
+        return Ok(());
+    }
+
+    spawn_daemon(work_dir)?;
+
     // Wait for the daemon socket to become available (up to 5 seconds).
-    let socket = core::ipc::global_socket_path();
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    while std::time::Instant::now() < deadline {
-        if socket.exists() && std::os::unix::net::UnixStream::connect(&socket).is_ok() {
+    // Check per-workspace socket first (mirrors send_daemon_request preference),
+    // then fall back to global socket.
+    let local_socket = core::ipc::socket_path(work_dir);
+    let global_socket = core::ipc::global_socket_path();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        if tokio::net::UnixStream::connect(&local_socket).await.is_ok()
+            || tokio::net::UnixStream::connect(&global_socket)
+                .await
+                .is_ok()
+        {
             return Ok(());
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
     }
 
     Err(color_eyre::eyre::eyre!(
@@ -517,7 +507,7 @@ async fn cmd_create(
         None
     };
 
-    ensure_daemon_running(&work_dir)?;
+    ensure_daemon_running(&work_dir).await?;
 
     // Register this workspace first (idempotent)
     let _ = core::ipc::send_daemon_request(
@@ -572,7 +562,7 @@ async fn cmd_create(
 }
 
 async fn cmd_send(work_dir: std::path::PathBuf, worktree: String, message: String) -> Result<()> {
-    ensure_daemon_running(&work_dir)?;
+    ensure_daemon_running(&work_dir).await?;
     let req = daemon::protocol::DaemonRequest::SendMessage {
         worktree_id: worktree,
         message,
@@ -593,7 +583,7 @@ async fn cmd_send(work_dir: std::path::PathBuf, worktree: String, message: Strin
 }
 
 async fn cmd_close(work_dir: std::path::PathBuf, worktree: String) -> Result<()> {
-    ensure_daemon_running(&work_dir)?;
+    ensure_daemon_running(&work_dir).await?;
     let req = daemon::protocol::DaemonRequest::CloseWorker {
         worktree_id: worktree,
     };
@@ -613,7 +603,7 @@ async fn cmd_close(work_dir: std::path::PathBuf, worktree: String) -> Result<()>
 }
 
 async fn cmd_merge(work_dir: std::path::PathBuf, worktree: String) -> Result<()> {
-    ensure_daemon_running(&work_dir)?;
+    ensure_daemon_running(&work_dir).await?;
     let req = daemon::protocol::DaemonRequest::MergeWorker {
         worktree_id: worktree,
     };


### PR DESCRIPTION
## Summary
- `swarm create`, `send`, `close`, and `merge` now automatically start the daemon if it isn't running, matching the behavior of the TUI (`swarm` with no subcommand)
- Extracts daemon spawn logic into a shared `ensure_daemon_running()` function that spawns the daemon and polls the Unix socket for up to 5 seconds
- Users see a brief `[swarm] Starting daemon...` message, then the command proceeds normally

## Test plan
- [ ] Run `swarm daemon stop` then `swarm create "test task"` — daemon should auto-start and create succeeds
- [ ] Run `swarm send <id> "msg"` with daemon stopped — should auto-start
- [ ] Run `swarm close <id>` with daemon stopped — should auto-start
- [ ] Run `swarm merge <id>` with daemon stopped — should auto-start
- [ ] Run any subcommand with daemon already running — no extra "Starting daemon..." message
- [ ] `cargo check -p apiari-swarm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)