### PR TITLE
chore: bump swarm version to 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari-swarm"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 description = "Run agents in parallel. Git worktrees + custom daemons + vibes."
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump `apiari-swarm` crate version from `0.1.2` to `0.1.3`

## Test plan
- [x] `cargo check -p apiari-swarm` passes
- [x] `cargo fmt -p apiari-swarm -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)