### PR TITLE
docs: remove macOS codesign requirement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,6 @@ cd swarm
 cargo install --path .
 ```
 
-**macOS users:** You must codesign after install (required for process management):
-
-```bash
-codesign -f -s - ~/.cargo/bin/swarm
-```
-
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary
- Removed the macOS codesign block from the install instructions in README.md
- The codesign step is no longer needed — users install from their own terminal, not from within Claude Code

## Test plan
- [x] Verify only the codesign block was removed, all other install instructions unchanged
- [x] No Rust code changed, only markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)