### PR TITLE
Remove macOS codesign requirement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,6 @@ cd swarm
 cargo install --path .
 ```
 
-**macOS users:** You must codesign after install (required for process management):
-
-```bash
-codesign -f -s - ~/.cargo/bin/swarm
-```
-
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary
- Remove the macOS codesign section from the install instructions
- Users install from their own terminal, not within Claude Code
- Keep all other install instructions unchanged

## Changes
- Removed the "macOS users: You must codesign after install" warning and `codesign -f -s - ~/.cargo/bin/swarm` command
- Install section now goes directly from `cargo install --path .` to Quick start

🤖 Generated with Claude Code