### PR TITLE
Expose client feature in apiari-swarm library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari-swarm"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 description = "Run agents in parallel. Git worktrees + custom daemons + vibes."
 license.workspace = true
@@ -50,6 +50,8 @@ default = ["daemon-ipc", "tui"]
 daemon-ipc = []
 # TUI dependencies (ratatui, crossterm, apiari-tui); disable for lightweight lib builds
 tui = ["dep:ratatui", "dep:crossterm", "dep:apiari-tui"]
+# Client feature: expose daemon protocol and IPC client for external crates
+client = ["daemon-ipc"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,33 @@
 /// `swarm` binary crate.
 pub mod core {
     pub mod agent;
+    #[cfg(feature = "client")]
+    pub mod ipc;
     pub mod state;
+}
+
+/// Daemon communication: protocol types and IPC client.
+///
+/// Exposed only with the `client` feature enabled. Allows external crates
+/// to communicate with the swarm daemon over its Unix socket.
+#[cfg(feature = "client")]
+pub mod daemon {
+    pub mod ipc_client;
+    pub mod protocol;
 }
 
 // Re-export the most commonly used types at the crate root for convenience.
 pub use core::agent::AgentKind;
 pub use core::state::{
     PaneState, PrInfo, SwarmState, WorkerPhase, WorktreeState, load_state, save_state, state_path,
+};
+
+// Client feature: expose daemon communication types for external crates
+#[cfg(feature = "client")]
+pub use core::ipc::{global_socket_path, socket_path};
+#[cfg(feature = "client")]
+pub use daemon::ipc_client::send_daemon_request;
+#[cfg(feature = "client")]
+pub use daemon::protocol::{
+    AgentEventWire, DaemonRequest, DaemonResponse, TaskDirPayload, WorkerInfo, WorkspaceInfo,
 };

--- a/tests/client_feature.rs
+++ b/tests/client_feature.rs
@@ -1,0 +1,120 @@
+//! Integration test for the `client` feature.
+//!
+//! Verifies that external crates can access daemon protocol types
+//! and serialize/deserialize them correctly.
+
+#[cfg(feature = "client")]
+mod client_feature_tests {
+    use apiari_swarm::{
+        AgentEventWire, DaemonRequest, DaemonResponse, global_socket_path, socket_path,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_daemon_request_ping_serializes() {
+        let req = DaemonRequest::Ping;
+        let json = serde_json::to_string(&req).expect("failed to serialize");
+        assert!(json.contains("\"action\":\"ping\""));
+    }
+
+    #[test]
+    fn test_daemon_request_list_workers_round_trip() {
+        let req = DaemonRequest::ListWorkers {
+            workspace: Some(PathBuf::from("/tmp/workspace")),
+        };
+        let json = serde_json::to_string(&req).expect("failed to serialize");
+        let restored: DaemonRequest = serde_json::from_str(&json).expect("failed to deserialize");
+        match restored {
+            DaemonRequest::ListWorkers { workspace } => {
+                assert_eq!(workspace, Some(PathBuf::from("/tmp/workspace")));
+            }
+            _ => panic!("expected ListWorkers variant"),
+        }
+    }
+
+    #[test]
+    fn test_daemon_response_ok_round_trip() {
+        let resp = DaemonResponse::Ok { data: None };
+        let json = serde_json::to_string(&resp).expect("failed to serialize");
+        let restored: DaemonResponse = serde_json::from_str(&json).expect("failed to deserialize");
+        assert!(matches!(restored, DaemonResponse::Ok { data: None }));
+    }
+
+    #[test]
+    fn test_daemon_response_error_round_trip() {
+        let resp = DaemonResponse::Error {
+            message: "test error".to_string(),
+        };
+        let json = serde_json::to_string(&resp).expect("failed to serialize");
+        let restored: DaemonResponse = serde_json::from_str(&json).expect("failed to deserialize");
+        match restored {
+            DaemonResponse::Error { message } => {
+                assert_eq!(message, "test error");
+            }
+            _ => panic!("expected Error variant"),
+        }
+    }
+
+    #[test]
+    fn test_agent_event_wire_text_delta() {
+        let event = AgentEventWire::TextDelta {
+            text: "hello world".to_string(),
+        };
+        let json = serde_json::to_string(&event).expect("failed to serialize");
+        assert!(json.contains("\"type\":\"text_delta\""));
+        let restored: AgentEventWire = serde_json::from_str(&json).expect("failed to deserialize");
+        match restored {
+            AgentEventWire::TextDelta { text } => {
+                assert_eq!(text, "hello world");
+            }
+            _ => panic!("expected TextDelta variant"),
+        }
+    }
+
+    #[test]
+    fn test_socket_path_functions_accessible() {
+        // Test that socket path functions are accessible from the crate root
+        let work_dir = PathBuf::from("/tmp/test-workspace");
+        let local_sock = socket_path(&work_dir);
+        assert!(local_sock.ends_with(".swarm/swarm.sock"));
+
+        let global_sock = global_socket_path();
+        assert!(global_sock.ends_with(".config/swarm/swarm.sock"));
+    }
+
+    #[test]
+    fn test_daemon_request_create_worker_minimal() {
+        let req = DaemonRequest::CreateWorker {
+            prompt: "fix the bug".to_string(),
+            agent: "claude".to_string(),
+            repo: None,
+            start_point: None,
+            workspace: None,
+            profile: None,
+            task_dir: None,
+        };
+        let json = serde_json::to_string(&req).expect("failed to serialize");
+        assert!(json.contains("\"action\":\"create_worker\""));
+        assert!(json.contains("\"prompt\":\"fix the bug\""));
+    }
+
+    #[test]
+    fn test_daemon_request_send_message() {
+        let req = DaemonRequest::SendMessage {
+            worktree_id: "hive-abc123".to_string(),
+            message: "please review the PR".to_string(),
+        };
+        let json = serde_json::to_string(&req).expect("failed to serialize");
+        let restored: DaemonRequest = serde_json::from_str(&json).expect("failed to deserialize");
+        match restored {
+            DaemonRequest::SendMessage {
+                worktree_id,
+                message,
+            } => {
+                assert_eq!(worktree_id, "hive-abc123");
+                assert_eq!(message, "please review the PR");
+            }
+            _ => panic!("expected SendMessage variant"),
+        }
+    }
+}


### PR DESCRIPTION
External crates can now use the swarm daemon client over Unix socket without needing the swarm binary. All 286 tests pass. Code formatted with cargo fmt.