### PR TITLE
fix: prepend worker profile to prompt instead of writing convention files

### DIFF
--- a/src/core/profile.rs
+++ b/src/core/profile.rs
@@ -20,6 +20,14 @@ pub fn load_profile(work_dir: &Path, slug: &str) -> String {
     format!("<!-- profile '{slug}' not found, using default -->\n{DEFAULT_PROFILE}")
 }
 
+/// Build the effective prompt by prepending the worker profile to the user's prompt.
+///
+/// This is the agent-agnostic way to inject profile content: it goes through the
+/// prompt rather than convention files, so it works for Claude, Codex, and Gemini.
+pub fn build_effective_prompt(profile: &str, user_prompt: &str) -> String {
+    format!("{profile}\n\n---\n\n{user_prompt}")
+}
+
 /// List available profile slugs from `.swarm/profiles/`.
 /// Always includes "default" (the embedded fallback).
 #[allow(dead_code)]
@@ -95,6 +103,19 @@ mod tests {
 
         let slugs = list_profiles(tmp.path());
         assert_eq!(slugs, vec!["default", "relaxed", "strict"]);
+    }
+
+    #[test]
+    fn build_effective_prompt_prepends_profile() {
+        let result = build_effective_prompt("# Profile", "Fix the bug");
+        assert_eq!(result, "# Profile\n\n---\n\nFix the bug");
+    }
+
+    #[test]
+    fn build_effective_prompt_preserves_user_prompt() {
+        let result = build_effective_prompt("# Profile", "Fix the bug");
+        assert!(result.ends_with("Fix the bug"));
+        assert!(result.starts_with("# Profile"));
     }
 
     #[test]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -960,11 +960,13 @@ async fn handle_request(
                 );
             }
 
-            // Load profile and prepend it to the prompt so it works for all agent kinds
-            // without touching any convention files (CLAUDE.md, AGENTS.md, etc.).
+            // Load profile and build an effective prompt (profile + user prompt) for
+            // the agent. The raw `prompt` is kept for display/persistence in WorkerState;
+            // only the agent spawn call receives the effective prompt.
             let profile_slug = profile.as_deref().unwrap_or("default");
             let profile_content = crate::core::profile::load_profile(&work_dir, profile_slug);
-            let prompt = format!("{profile_content}\n\n---\n\n{prompt}");
+            let effective_prompt =
+                crate::core::profile::build_effective_prompt(&profile_content, &prompt);
 
             // Seed .task/ directory if artifacts provided
             if let Some(ref payload) = task_dir {
@@ -1004,7 +1006,7 @@ async fn handle_request(
             let msg_tx = spawn_worker_agent(
                 worktree_id.clone(),
                 kind.clone(),
-                prompt.clone(),
+                effective_prompt,
                 worktree_path.clone(),
                 work_dir.clone(),
                 None, // new worker, no session to resume


### PR DESCRIPTION
## Summary
- Profile content is now prepended to the agent prompt via `build_effective_prompt()` instead of writing to convention files (`CLAUDE.md`, `AGENTS.md`, etc.)
- Raw user prompt is preserved in `ManagedWorker` state for display/persistence; only the agent spawn call receives the effective (profile + user) prompt
- Removed `inject_profile()`, `convention_filename()`, and all file-writing profile code
- Works uniformly for Claude, Codex, and Gemini — no filesystem side effects

## Test plan
- [x] `build_effective_prompt()` unit tests verify profile is prepended and user prompt preserved
- [x] `load_profile()` / `list_profiles()` tests unchanged and passing
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)