### PR TITLE
chore: bump swarm version to 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari-swarm"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 description = "Run agents in parallel. Git worktrees + custom daemons + vibes."
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump `apiari-swarm` crate version from 0.1.4 to 0.1.5 in Cargo.toml

## Test plan
- [ ] CI passes (`cargo check`, `cargo fmt --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)