### PR TITLE
feat: add close_on_pr_merge config toggle

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,0 +1,87 @@
+use serde::Deserialize;
+use std::path::Path;
+
+/// Workspace-level swarm configuration, read from `.swarm/config.toml`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SwarmConfig {
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub default_agent: Option<String>,
+
+    /// When true (the default), workers are automatically closed when their PR
+    /// is merged. Set to false to keep the worker alive after merge.
+    #[serde(default = "default_true")]
+    pub close_on_pr_merge: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for SwarmConfig {
+    fn default() -> Self {
+        Self {
+            default_agent: None,
+            close_on_pr_merge: true,
+        }
+    }
+}
+
+/// Load the swarm config from `.swarm/config.toml` in the given workspace.
+/// Returns `SwarmConfig::default()` if the file is missing or unparseable.
+pub fn load_config(workspace_path: &Path) -> SwarmConfig {
+    let config_path = workspace_path.join(".swarm").join("config.toml");
+    match std::fs::read_to_string(&config_path) {
+        Ok(content) => toml::from_str(&content).unwrap_or_default(),
+        Err(_) => SwarmConfig::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_close_on_pr_merge_true() {
+        let config = SwarmConfig::default();
+        assert!(config.close_on_pr_merge);
+    }
+
+    #[test]
+    fn parse_config_without_close_on_pr_merge() {
+        let toml_str = r#"default_agent = "claude""#;
+        let config: SwarmConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.close_on_pr_merge);
+        assert_eq!(config.default_agent.as_deref(), Some("claude"));
+    }
+
+    #[test]
+    fn parse_config_with_close_on_pr_merge_false() {
+        let toml_str = r#"
+default_agent = "claude"
+close_on_pr_merge = false
+"#;
+        let config: SwarmConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.close_on_pr_merge);
+    }
+
+    #[test]
+    fn parse_config_with_close_on_pr_merge_true() {
+        let toml_str = r#"close_on_pr_merge = true"#;
+        let config: SwarmConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.close_on_pr_merge);
+    }
+
+    #[test]
+    fn load_config_missing_file_returns_default() {
+        let config = load_config(Path::new("/tmp/nonexistent-workspace-12345"));
+        assert!(config.close_on_pr_merge);
+    }
+
+    #[test]
+    fn parse_empty_config() {
+        let config: SwarmConfig = toml::from_str("").unwrap();
+        assert!(config.close_on_pr_merge);
+        assert!(config.default_agent.is_none());
+    }
+}

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -32,8 +32,18 @@ impl Default for SwarmConfig {
 pub fn load_config(workspace_path: &Path) -> SwarmConfig {
     let config_path = workspace_path.join(".swarm").join("config.toml");
     match std::fs::read_to_string(&config_path) {
-        Ok(content) => toml::from_str(&content).unwrap_or_default(),
-        Err(_) => SwarmConfig::default(),
+        Ok(content) => match toml::from_str(&content) {
+            Ok(config) => config,
+            Err(e) => {
+                tracing::warn!(path = %config_path.display(), error = %e, "Failed to parse config.toml, using defaults");
+                SwarmConfig::default()
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => SwarmConfig::default(),
+        Err(e) => {
+            tracing::warn!(path = %config_path.display(), error = %e, "Failed to read config.toml, using defaults");
+            SwarmConfig::default()
+        }
     }
 }
 
@@ -74,7 +84,8 @@ close_on_pr_merge = false
 
     #[test]
     fn load_config_missing_file_returns_default() {
-        let config = load_config(Path::new("/tmp/nonexistent-workspace-12345"));
+        let dir = tempfile::tempdir().unwrap();
+        let config = load_config(dir.path());
         assert!(config.close_on_pr_merge);
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod agent_card;
+pub mod config;
 pub mod git;
 pub mod ipc;
 pub mod log;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -56,6 +56,8 @@ struct WorkspaceState {
     repos: Vec<PathBuf>,
     workers: HashMap<String, ManagedWorker>,
     inbox_offset: u64,
+    /// Whether to auto-close workers when their PR is merged.
+    close_on_pr_merge: bool,
 }
 
 /// State for a managed worker within the daemon.
@@ -313,6 +315,7 @@ async fn register_workspace(
     let worker_count = workers.len();
     // Seek to end of inbox so we don't replay old messages on restart
     let inbox_pos = inbox_file_size(&canonical);
+    let config = crate::core::config::load_config(&canonical);
     workspaces.insert(
         canonical.clone(),
         WorkspaceState {
@@ -320,6 +323,7 @@ async fn register_workspace(
             repos,
             workers,
             inbox_offset: inbox_pos,
+            close_on_pr_merge: config.close_on_pr_merge,
         },
     );
 
@@ -460,11 +464,13 @@ async fn run_daemon(
                 let worker_count = workers.len();
                 let repo_count = repos.len();
                 let inbox_pos = inbox_file_size(&canonical);
+                let config = crate::core::config::load_config(&canonical);
                 let ws = WorkspaceState {
                     path: canonical.clone(),
                     repos,
                     workers,
                     inbox_offset: inbox_pos,
+                    close_on_pr_merge: config.close_on_pr_merge,
                 };
                 tracing::info!(
                     path = %canonical.display(),
@@ -1811,8 +1817,8 @@ fn apply_pr_poll_results(
             worker.pr = Some(result.pr);
             *state_dirty = true;
 
-            // Auto-close workers whose PR has been merged
-            if is_merged {
+            // Auto-close workers whose PR has been merged (if enabled for this workspace)
+            if is_merged && ws.close_on_pr_merge {
                 tracing::info!(
                     worker_id = %worker.id,
                     pr_number = worker.pr.as_ref().unwrap().number,
@@ -1909,6 +1915,7 @@ mod tests {
             repos: vec![],
             workers: ws_workers,
             inbox_offset: 0,
+            close_on_pr_merge: true,
         }
     }
 
@@ -2322,6 +2329,42 @@ mod tests {
             }
             other => panic!("expected StateChanged, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn apply_pr_poll_results_skips_close_when_disabled() {
+        let mut workspaces = HashMap::new();
+        let ws_path = PathBuf::from("/tmp/ws");
+        let mut ws = test_workspace("/tmp/ws", vec!["w-1"]);
+        ws.close_on_pr_merge = false;
+        workspaces.insert(ws_path.clone(), ws);
+
+        let results = vec![PrPollResult {
+            worker_id: "w-1".to_string(),
+            workspace_path: ws_path.clone(),
+            pr: PrInfo {
+                number: 42,
+                title: "merged pr".to_string(),
+                state: "MERGED".to_string(),
+                url: "https://github.com/test/repo/pull/42".to_string(),
+            },
+            is_new: false,
+        }];
+
+        let mut state_dirty = false;
+        let (event_tx, _event_rx) = broadcast::channel(16);
+        apply_pr_poll_results(results, &mut workspaces, &mut state_dirty, &event_tx);
+
+        // Worker should still exist — not auto-closed
+        let worker = workspaces
+            .get(&ws_path)
+            .unwrap()
+            .workers
+            .get("w-1")
+            .expect("worker should still exist");
+        assert_eq!(worker.pr.as_ref().unwrap().state, "MERGED");
+        assert_eq!(worker.phase, WorkerPhase::Running);
+        assert!(state_dirty);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `close_on_pr_merge` option to `.swarm/config.toml` (default: `true`) that controls whether workers are auto-closed when their PR is merged
- When `false`, PR state still updates but the worker stays alive (no worktree removal, no branch deletion, no WorktreeClosed event)
- New `src/core/config.rs` module with `SwarmConfig` struct and `load_config()` function

## Test plan
- [x] `apply_pr_poll_results_auto_closes_merged_pr` — existing test still passes (default behavior)
- [x] `apply_pr_poll_results_skips_close_when_disabled` — new test: PR state updates but worker stays alive
- [x] 6 config parsing tests: default values, missing field, explicit true/false, empty config, missing file
- [x] `cargo clippy -p apiari-swarm -- -D warnings` passes
- [x] All 314 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)