### PR TITLE
fix: update stale dependency versions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,16 @@ jobs:
           uuid = { version = "1", features = ["v4"] }
           thiserror = "2"
           tracing = "0.1"
+          tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+          tracing-appender = "0.2"
           libc = "0.2"
-          ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
+          ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
           crossterm = { version = "0.28", features = ["event-stream"] }
           apiari-common = "0.1.0"
-          apiari-tui = "0.2.0"
-          apiari-claude-sdk = { version = "0.1.0", path = "claude-sdk" }
-          apiari-codex-sdk = { version = "0.1.0", path = "codex-sdk" }
-          apiari-gemini-sdk = { version = "0.1.0", path = "gemini-sdk" }
+          apiari-tui = "0.3.0"
+          apiari-claude-sdk = { version = "0.2.0", path = "claude-sdk" }
+          apiari-codex-sdk = { version = "0.1.1", path = "codex-sdk" }
+          apiari-gemini-sdk = { version = "0.2.0", path = "gemini-sdk" }
           TOML
 
       - uses: dtolnay/rust-toolchain@stable
@@ -145,14 +147,16 @@ jobs:
           uuid = { version = "1", features = ["v4"] }
           thiserror = "2"
           tracing = "0.1"
+          tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+          tracing-appender = "0.2"
           libc = "0.2"
-          ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
+          ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
           crossterm = { version = "0.28", features = ["event-stream"] }
           apiari-common = "0.1.0"
-          apiari-tui = "0.2.0"
-          apiari-claude-sdk = { version = "0.1.0", path = "claude-sdk" }
-          apiari-codex-sdk = { version = "0.1.0", path = "codex-sdk" }
-          apiari-gemini-sdk = { version = "0.1.0", path = "gemini-sdk" }
+          apiari-tui = "0.3.0"
+          apiari-claude-sdk = { version = "0.2.0", path = "claude-sdk" }
+          apiari-codex-sdk = { version = "0.1.1", path = "codex-sdk" }
+          apiari-gemini-sdk = { version = "0.2.0", path = "gemini-sdk" }
           TOML
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Updated hardcoded dependency versions in the release workflow's synthetic `Cargo.toml` (both build and publish jobs) to match the current workspace
- Bumped: apiari-tui 0.2→0.3, apiari-claude-sdk 0.1→0.2, apiari-codex-sdk 0.1→0.1.1, apiari-gemini-sdk 0.1→0.2, ratatui 0.29→0.30
- Added missing `tracing-subscriber` and `tracing-appender` workspace dependencies

## Test plan
- [ ] Trigger a release build and verify it compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)