### PR TITLE
fix: use crates.io deps instead of checking out SDK repos in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,30 +30,12 @@ jobs:
         with:
           path: swarm
 
-      - name: Checkout apiari-claude-sdk
-        uses: actions/checkout@v4
-        with:
-          repository: ApiariTools/apiari-claude-sdk
-          path: claude-sdk
-
-      - name: Checkout apiari-codex-sdk
-        uses: actions/checkout@v4
-        with:
-          repository: ApiariTools/apiari-codex-sdk
-          path: codex-sdk
-
-      - name: Checkout apiari-gemini-sdk
-        uses: actions/checkout@v4
-        with:
-          repository: ApiariTools/gemini-sdk
-          path: gemini-sdk
-
       - name: Create workspace root
         run: |
           cat > Cargo.toml << 'TOML'
           [workspace]
           resolver = "3"
-          members = ["swarm", "claude-sdk", "codex-sdk", "gemini-sdk"]
+          members = ["swarm"]
 
           [workspace.package]
           edition = "2024"
@@ -76,9 +58,9 @@ jobs:
           crossterm = { version = "0.28", features = ["event-stream"] }
           apiari-common = "0.1.0"
           apiari-tui = "0.3.0"
-          apiari-claude-sdk = { version = "0.2.0", path = "claude-sdk" }
-          apiari-codex-sdk = { version = "0.1.1", path = "codex-sdk" }
-          apiari-gemini-sdk = { version = "0.2.0", path = "gemini-sdk" }
+          apiari-claude-sdk = "0.2.0"
+          apiari-codex-sdk = "0.1.2"
+          apiari-gemini-sdk = "0.2.0"
           TOML
 
       - uses: dtolnay/rust-toolchain@stable
@@ -108,30 +90,12 @@ jobs:
         with:
           path: swarm
 
-      - name: Checkout apiari-claude-sdk
-        uses: actions/checkout@v4
-        with:
-          repository: ApiariTools/apiari-claude-sdk
-          path: claude-sdk
-
-      - name: Checkout apiari-codex-sdk
-        uses: actions/checkout@v4
-        with:
-          repository: ApiariTools/apiari-codex-sdk
-          path: codex-sdk
-
-      - name: Checkout apiari-gemini-sdk
-        uses: actions/checkout@v4
-        with:
-          repository: ApiariTools/gemini-sdk
-          path: gemini-sdk
-
       - name: Create workspace root
         run: |
           cat > Cargo.toml << 'TOML'
           [workspace]
           resolver = "3"
-          members = ["swarm", "claude-sdk", "codex-sdk", "gemini-sdk"]
+          members = ["swarm"]
 
           [workspace.package]
           edition = "2024"
@@ -154,9 +118,9 @@ jobs:
           crossterm = { version = "0.28", features = ["event-stream"] }
           apiari-common = "0.1.0"
           apiari-tui = "0.3.0"
-          apiari-claude-sdk = { version = "0.2.0", path = "claude-sdk" }
-          apiari-codex-sdk = { version = "0.1.1", path = "codex-sdk" }
-          apiari-gemini-sdk = { version = "0.2.0", path = "gemini-sdk" }
+          apiari-claude-sdk = "0.2.0"
+          apiari-codex-sdk = "0.1.2"
+          apiari-gemini-sdk = "0.2.0"
           TOML
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Removed checkout steps for `apiari-claude-sdk`, `apiari-codex-sdk`, and `apiari-gemini-sdk` from both `build` and `publish` jobs
- Changed SDK workspace dependencies from path-based (`{ version = "...", path = "..." }`) to crates.io-only (version string)
- Fixed `apiari-codex-sdk` version from `0.1.1` to `0.1.2` (the actual crates.io version)
- Reduced workspace `members` to just `["swarm"]` since SDK crates are no longer checked out

The SDKs are already published on crates.io at the correct versions. Checking them out was causing build failures because the local repos had stale version numbers (e.g., gemini-sdk repo says 0.1.0 but workspace requests ^0.2.0).

## Test plan
- [ ] Verify release workflow succeeds on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)