### PR TITLE
fix: start daemon in-process instead of shelling out to subprocess

### DIFF
--- a/src/core/log.rs
+++ b/src/core/log.rs
@@ -24,11 +24,13 @@ pub fn init(work_dir: &Path) -> tracing_appender::non_blocking::WorkerGuard {
     let appender = tracing_appender::rolling::never(&log_dir, "swarm.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(appender);
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    fmt()
+    // Use try_init so this is a no-op when a subscriber is already set
+    // (e.g. when run_daemon is called in-process after init_stderr).
+    let _ = fmt()
         .with_env_filter(filter)
         .with_writer(non_blocking)
         .with_ansi(false)
         .with_target(false)
-        .init();
+        .try_init();
     guard
 }

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -17,6 +17,9 @@ pub fn is_daemon_running(_work_dir: &Path) -> bool {
 /// Launches `run_daemon` on a detached tokio task so the daemon runs within
 /// the current process. This avoids shelling out to `current_exe()`, which
 /// breaks when an external binary (e.g. `hive`) embeds apiari-swarm as a library.
+///
+/// # Panics
+/// Panics if called outside a tokio runtime.
 pub fn spawn_daemon(work_dir: &Path) {
     tracing::info!("Starting daemon...");
     let work_dir = work_dir.to_path_buf();
@@ -54,6 +57,6 @@ pub async fn ensure_daemon_running(work_dir: &Path) -> Result<()> {
     }
 
     Err(color_eyre::eyre::eyre!(
-        "daemon failed to start within 5 seconds — check logs"
+        "daemon failed to start within 5 seconds — check .swarm/swarm.log"
     ))
 }

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -12,38 +12,19 @@ pub fn is_daemon_running(_work_dir: &Path) -> bool {
     super::read_global_pid().is_some_and(super::is_process_alive)
 }
 
-/// Spawn the daemon process in the background.
+/// Spawn the daemon as an in-process background task.
 ///
-/// Launches the `swarm daemon start --foreground` command as a detached child
-/// process, redirecting stderr to `.swarm/daemon-stderr.log`.
-pub fn spawn_daemon(work_dir: &Path) -> Result<()> {
+/// Launches `run_daemon` on a detached tokio task so the daemon runs within
+/// the current process. This avoids shelling out to `current_exe()`, which
+/// breaks when an external binary (e.g. `hive`) embeds apiari-swarm as a library.
+pub fn spawn_daemon(work_dir: &Path) {
     tracing::info!("Starting daemon...");
-    let exe = std::env::current_exe()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|_| "swarm".to_string());
-
-    let log_dir = work_dir.join(".swarm");
-    std::fs::create_dir_all(&log_dir).ok();
-    let stderr_cfg = std::fs::File::create(log_dir.join("daemon-stderr.log"))
-        .or_else(|_| std::fs::File::open("/dev/null"))
-        .map(std::process::Stdio::from)
-        .unwrap_or_else(|_| std::process::Stdio::null());
-
-    std::process::Command::new(&exe)
-        .args([
-            "-d",
-            &work_dir.to_string_lossy(),
-            "daemon",
-            "start",
-            "--foreground",
-        ])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(stderr_cfg)
-        .spawn()
-        .map_err(|e| color_eyre::eyre::eyre!("failed to spawn daemon: {}", e))?;
-
-    Ok(())
+    let work_dir = work_dir.to_path_buf();
+    tokio::spawn(async move {
+        if let Err(e) = super::run_daemon(Some(work_dir), None, None).await {
+            tracing::error!(error = %e, "Daemon task exited with error");
+        }
+    });
 }
 
 /// Ensure the daemon is running, starting it if necessary.
@@ -55,7 +36,7 @@ pub async fn ensure_daemon_running(work_dir: &Path) -> Result<()> {
         return Ok(());
     }
 
-    spawn_daemon(work_dir)?;
+    spawn_daemon(work_dir);
 
     // Wait for the daemon socket to become available (up to 5 seconds).
     let local_socket = crate::core::ipc::socket_path(work_dir);
@@ -73,6 +54,6 @@ pub async fn ensure_daemon_running(work_dir: &Path) -> Result<()> {
     }
 
     Err(color_eyre::eyre::eyre!(
-        "daemon failed to start within 5 seconds — check .swarm/daemon-stderr.log"
+        "daemon failed to start within 5 seconds — check logs"
     ))
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -350,7 +350,7 @@ async fn register_workspace(
 // ── Main daemon loop ─────────────────────────────────────
 
 /// The main daemon event loop.
-async fn run_daemon(
+pub(crate) async fn run_daemon(
     initial_work_dir: Option<PathBuf>,
     tcp_bind: Option<String>,
     auth_token: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ async fn run_default_tui(work_dir: std::path::PathBuf) -> Result<()> {
 
     if !daemon::lifecycle::is_daemon_running(&work_dir) {
         // TUI has its own reconnect loop, so just spawn — don't block on readiness.
-        daemon::lifecycle::spawn_daemon(&work_dir)?;
+        daemon::lifecycle::spawn_daemon(&work_dir);
     } else {
         // Daemon already running — register workspace in background (don't block TUI startup)
         let bg_dir = work_dir.clone();


### PR DESCRIPTION
## Summary
- Replace `spawn_daemon()`'s subprocess spawn (`std::process::Command` + `current_exe()`) with a detached `tokio::spawn` that calls `run_daemon()` directly
- This fixes the `server` feature library use case where `current_exe()` returns the host binary (e.g. `hive`) which doesn't have a `daemon` subcommand
- Made `run_daemon` `pub(crate)` so it's accessible from the `lifecycle` submodule

## Test plan
- [x] `cargo check` passes
- [ ] Verify daemon starts correctly when launched via `swarm` CLI
- [ ] Verify daemon starts correctly when launched via library consumer (e.g. `hive`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)