### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apiari-swarm"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 description = "Run agents in parallel. Git worktrees + custom daemons + vibes."
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bumps version in Cargo.toml from 0.1.7 to 0.1.8
- Tag `v0.1.8` and GitHub release already created

## Note
`cargo publish` could not complete because workspace path dependencies (`apiari-common`, `apiari-tui`, `apiari-claude-sdk`, etc.) lack crates.io version specifiers. This needs to be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)