### PR TITLE
fix: set DangerFullAccess sandbox for codex and yolo for gemini workers

### DIFF
--- a/src/daemon/managed_agent.rs
+++ b/src/daemon/managed_agent.rs
@@ -328,6 +328,7 @@ impl CodexManagedAgent {
                     &opts.prompt,
                     apiari_codex_sdk::ExecOptions {
                         full_auto: true,
+                        sandbox: Some(apiari_codex_sdk::SandboxMode::DangerFullAccess),
                         working_dir: Some(opts.working_dir.clone()),
                         ..Default::default()
                     },
@@ -535,6 +536,7 @@ impl GeminiManagedAgent {
                     apiari_gemini_sdk::SessionOptions {
                         session_id: Some(session_id.clone()),
                         working_dir: Some(opts.working_dir.clone()),
+                        yolo: true,
                         ..Default::default()
                     },
                 )
@@ -545,6 +547,7 @@ impl GeminiManagedAgent {
                     &opts.prompt,
                     apiari_gemini_sdk::GeminiOptions {
                         working_dir: Some(opts.working_dir.clone()),
+                        yolo: true,
                         ..Default::default()
                     },
                 )


### PR DESCRIPTION
## Summary
- **Codex**: Added `SandboxMode::DangerFullAccess` to `ExecOptions` in `spawn()` so workers can write files anywhere in the repo, not just within the workspace directory
- **Gemini**: Added `yolo: true` to both `GeminiOptions` (fresh exec) and `SessionOptions` (resume exec) so the gemini CLI runs non-interactively without stalling for user approval
- **gemini-sdk**: Bumped to v0.2.1, adding `yolo: bool` field to `GeminiOptions` and `SessionOptions` with `--yolo` CLI arg support in `to_cli_args()`

## Test plan
- [ ] `cargo clippy -p apiari-swarm -- -D warnings` passes
- [ ] `cargo test -p apiari-swarm` passes (326 tests)
- [ ] `cargo test -p apiari-gemini-sdk` passes (24 tests, including new `test_yolo_option` and `test_session_yolo_option`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)